### PR TITLE
Add a basic ordering from CLI flag to jsonListToTable results.

### DIFF
--- a/include/Client.h
+++ b/include/Client.h
@@ -229,6 +229,8 @@ public:
 	void copySecret(const SecretCopyOptions& opt);
 
 	void deleteSecret(const SecretDeleteOptions& opt);
+
+	std::string orderBy = "Owner";
 	
 private:
 	///Get the default path to the user's API endpoint file
@@ -300,6 +302,7 @@ private:
 	  void ShowSomeProgress();
 	  void StopShowingProgress();
 	};
+	
 	///The progress bar manager
 	ProgressManager pman_;
 
@@ -311,6 +314,7 @@ private:
 	
 	std::string jsonListToTable(const rapidjson::Value& jdata,
 	                            const std::vector<columnSpec>& columns,
+				    const std::vector<std::string>& labels,
 				    const bool headers) const;
 
 	std::string displayContents(const rapidjson::Value& jdata,

--- a/include/Client.h
+++ b/include/Client.h
@@ -230,7 +230,7 @@ public:
 
 	void deleteSecret(const SecretDeleteOptions& opt);
 
-	std::string orderBy = "Owner";
+	std::string orderBy = "";
 	
 private:
 	///Get the default path to the user's API endpoint file
@@ -314,7 +314,6 @@ private:
 	
 	std::string jsonListToTable(const rapidjson::Value& jdata,
 	                            const std::vector<columnSpec>& columns,
-				    const std::vector<std::string>& labels,
 				    const bool headers) const;
 
 	std::string displayContents(const rapidjson::Value& jdata,

--- a/src/slate_client.cpp
+++ b/src/slate_client.cpp
@@ -306,6 +306,8 @@ void registerSecretCommands(CLI::App& parent, Client& client){
 }
 
 void registerCommonOptions(CLI::App& parent, Client& client){
+	parent.add_option("--orderBy", client.orderBy, "the name of a column in the JSON output"
+			"by which to order the table printed to stdout.");
 	parent.add_flag_function("--no-format", 
 	                         [&](std::size_t){ client.setUseANSICodes(false); }, 
 	                         "Do not use ANSI formatting escape sequences in output");


### PR DESCRIPTION
From the --orderBy CLI argument, sort the output of Client's method, jsonListToTable, by some column name, or the first column name if there is no match.