### PR TITLE
AWS C++ SDK install instructions cmake to cmake 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ In a suitable location:
 	tar xzf 1.7.25.tar.gz
 	mkdir aws-sdk-cpp-1.7.25-build
 	cd aws-sdk-cpp-1.7.25-build
-	cmake3 ../aws-sdk-cpp-1.7.25 -DBUILD_ONLY="dynamodb;route53" -DBUILD_SHARED_LIBS=Off
+	cmake ../aws-sdk-cpp-1.7.25 -DBUILD_ONLY="dynamodb;route53" -DBUILD_SHARED_LIBS=Off
 	make
 	sudo make install
-
+Note that if you are using CentOS, you 
 
 Building:
 =========
@@ -94,7 +94,7 @@ In the slate-client-server directory:
 
 	mkdir build
 	cd build
-	cmake3 .. [options]
+	cmake .. [options]
 	make
 	
 Options for cmake include:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ In a suitable location:
 	tar xzf 1.7.25.tar.gz
 	mkdir aws-sdk-cpp-1.7.25-build
 	cd aws-sdk-cpp-1.7.25-build
-	cmake ../aws-sdk-cpp-1.7.25 -DBUILD_ONLY="dynamodb" -DBUILD_SHARED_LIBS=Off
+	cmake3 ../aws-sdk-cpp-1.7.25 -DBUILD_ONLY="dynamodb;route53" -DBUILD_SHARED_LIBS=Off
 	make
 	sudo make install
 
@@ -94,7 +94,7 @@ In the slate-client-server directory:
 
 	mkdir build
 	cd build
-	cmake .. [options]
+	cmake3 .. [options]
 	make
 	
 Options for cmake include:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ In a suitable location:
 	cmake ../aws-sdk-cpp-1.7.25 -DBUILD_ONLY="dynamodb;route53" -DBUILD_SHARED_LIBS=Off
 	make
 	sudo make install
-Note that if you are using CentOS, you 
 
 Building:
 =========


### PR DESCRIPTION
if one follows the AWS C++ SDK install instructions verbatim an error will occur "CMake 3.1 or higher is required.  You are running version 2.8.12.2". Running the same command with cmake3 works however. Additionally adding route53 to the cmake3 command (excluding this will cause build errors). Just a minor fix to improve correctness.