### PR TITLE
Adding instance replica tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,6 +510,9 @@ if(BUILD_SERVER)
     
     slate_add_test(test-instance-deletion
         SOURCE_FILES test/TestInstanceDeletion.cpp)
+
+    slate_add_test(test-instance-scaling
+        SOURCE_FILES test/TestInstanceScale.cpp)
     
     slate_add_test(test-secret-listing
         SOURCE_FILES test/TestSecretListing.cpp)

--- a/test/TestInstanceScale.cpp
+++ b/test/TestInstanceScale.cpp
@@ -22,12 +22,12 @@ TEST(UnauthenticatedInstanceSetReplicas){
 	TestContext tc;
 
     // Try to get 
-    auto infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/ABC/scale?replicas=3");
+    auto infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/ABC/scale?replicas=3", "");
     ENSURE_EQUAL(infoResp.status,403,
 				 "Requests to get instance replica info without authentication should be rejected");
     
     // try listing instances with invalid authentication
-	infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/ABC/scale?token=00112233-4455-6677-8899-aabbccddeeff&replicas=3");
+	infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/ABC/scale?token=00112233-4455-6677-8899-aabbccddeeff&replicas=3", "");
 	ENSURE_EQUAL(infoResp.status,403,
 				 "Requests to get instance replica info with invalid authentication should be rejected");
 }
@@ -105,7 +105,7 @@ TEST(FetchAndSetInstanceReplicas){
 
     { // Get replica info
         auto infoResp=httpGet(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+instID+"/scale?token="+adminKey);
-        ENSURE_EQUAL(instResp.status,200,"Application get instance scale request should succeed");
+        ENSURE_EQUAL(infoResp.status,200,"Application get instance scale request should succeed");
         rapidjson::Document data;
         data.Parse(infoResp.body);
         ENSURE_CONFORMS(data,schema);
@@ -113,8 +113,8 @@ TEST(FetchAndSetInstanceReplicas){
     }
 
     { // Rescale replica
-        auto infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+instID+"/scale?token="+adminKey+"&replicas=3");
-        ENSURE_EQUAL(instResp.status,200,"Application change instance scale to 3 should succeed");
+        auto infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+instID+"/scale?token="+adminKey+"&replicas=3", "");
+        ENSURE_EQUAL(infoResp.status,200,"Application change instance scale to 3 should succeed");
         rapidjson::Document data;
         data.Parse(infoResp.body);
         ENSURE_CONFORMS(data,schema);
@@ -122,8 +122,8 @@ TEST(FetchAndSetInstanceReplicas){
     }
 
     { // Rescale replica again!
-        auto infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+instID+"/scale?token="+adminKey+"&replicas=2");
-        ENSURE_EQUAL(instResp.status,200,"Application change instance scale to 2 should succeed");
+        auto infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+instID+"/scale?token="+adminKey+"&replicas=2", "");
+        ENSURE_EQUAL(infoResp.status,200,"Application change instance scale to 2 should succeed");
         rapidjson::Document data;
         data.Parse(infoResp.body);
         ENSURE_CONFORMS(data,schema);
@@ -230,7 +230,7 @@ TEST(UnrelatedUserInstanceReplicas){
 	}
 
     { // have the new user attempt to set replica count
-		auto infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+instID+"/scale?token="+tok+"&replicas=3");
+		auto infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+instID+"/scale?token="+tok+"&replicas=3", "");
 		ENSURE_EQUAL(infoResp.status,403,
 		             "Requests to change replica count from users who do not belong to"
 		             " the owning Group should be rejected.");

--- a/test/TestInstanceScale.cpp
+++ b/test/TestInstanceScale.cpp
@@ -33,13 +33,13 @@ TEST(UnauthenticatedInstanceSetReplicas){
 }
 
 TEST(FetchAndSetInstanceReplicas){
-    using namespace httpRequests;
+	using namespace httpRequests;
 	TestContext tc;
 
-    std::string adminKey=tc.getPortalToken();
+	std::string adminKey=tc.getPortalToken();
 	auto schema=loadSchema(getSchemaDir()+"/InstanceScaleResultSchema.json");
 
-    const std::string groupName="test-fetch-inst-scale";
+	const std::string groupName="test-fetch-inst-scale";
 	const std::string clusterName="test-get-scale-cluster";
 
     { // create a VO
@@ -71,7 +71,7 @@ TEST(FetchAndSetInstanceReplicas){
 		ENSURE(!createResp.body.empty());
 	}
 
-    std::string instID;
+	std::string instID;
 	std::string instName;
 	struct cleanupHelper{
 		TestContext& tc;
@@ -84,7 +84,7 @@ TEST(FetchAndSetInstanceReplicas){
 		}
 	} cleanup(tc,instID,adminKey);
 
-    const std::string application="test-app";
+	const std::string application="test-app";
 	const std::string config1="num: 2571008";
 	const std::string config2="thing: foobar";
 
@@ -143,13 +143,13 @@ TEST(FetchAndSetInstanceReplicas){
 }
 
 TEST(UnrelatedUserInstanceReplicas){
-    using namespace httpRequests;
+	using namespace httpRequests;
 	TestContext tc;
 
-    std::string adminKey=tc.getPortalToken();
+	std::string adminKey=tc.getPortalToken();
 	auto schema=loadSchema(getSchemaDir()+"/InstanceScaleResultSchema.json");
 
-    const std::string groupName="test-unreluser-fetch-inst-scale";
+	const std::string groupName="test-unreluser-fetch-inst-scale";
 	const std::string clusterName="test-get-scale-cluster-unreluser";
 
     { // create a VO
@@ -181,7 +181,7 @@ TEST(UnrelatedUserInstanceReplicas){
 		ENSURE(!createResp.body.empty());
 	}
 
-    std::string instID;
+	std::string instID;
 	struct cleanupHelper{
 		TestContext& tc;
 		const std::string& id, key;
@@ -193,7 +193,7 @@ TEST(UnrelatedUserInstanceReplicas){
 		}
 	} cleanup(tc,instID,adminKey);
 
-    const std::string application="test-app";
+	const std::string application="test-app";
 	const std::string config1="num: 345";
 	const std::string config2="thing: barfoo";
 

--- a/test/TestInstanceScale.cpp
+++ b/test/TestInstanceScale.cpp
@@ -6,7 +6,7 @@ TEST(UnauthenticatedInstanceFetchReplicas){
     using namespace httpRequests;
 	TestContext tc;
 
-    // Try to get 
+    // Try to get scale without authentication
     auto infoResp=httpGet(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/ABC/scale");
     ENSURE_EQUAL(infoResp.status,403,
 				 "Requests to get instance replica info without authentication should be rejected");
@@ -21,7 +21,7 @@ TEST(UnauthenticatedInstanceSetReplicas){
     using namespace httpRequests;
 	TestContext tc;
 
-    // Try to set 
+    // Try to set without authentication
     auto infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/ABC/scale?replicas=3", "");
     ENSURE_EQUAL(infoResp.status,403,
 				 "Requests to rescale instance without authentication should be rejected");
@@ -36,7 +36,7 @@ TEST(FetchAndSetInstanceReplicas){
     using namespace httpRequests;
 	TestContext tc;
 
-    std::string adminKey=getPortalToken();
+    std::string adminKey=tc.getPortalToken();
 	auto schema=loadSchema(getSchemaDir()+"/InstanceScaleResultSchema.json");
 
     const std::string groupName="test-fetch-inst-scale";
@@ -146,7 +146,7 @@ TEST(UnrelatedUserInstanceReplicas){
     using namespace httpRequests;
 	TestContext tc;
 
-    std::string adminKey=getPortalToken();
+    std::string adminKey=tc.getPortalToken();
 	auto schema=loadSchema(getSchemaDir()+"/InstanceScaleResultSchema.json");
 
     const std::string groupName="test-unreluser-fetch-inst-scale";

--- a/test/TestInstanceScale.cpp
+++ b/test/TestInstanceScale.cpp
@@ -1,0 +1,238 @@
+#include "test.h"
+
+#include <ServerUtilities.h>
+
+TEST(UnauthenticatedInstanceFetchReplicas){
+    using namespace httpRequests;
+	TestContext tc;
+
+    // Try to get 
+    auto infoResp=httpGet(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/ABC/scale");
+    ENSURE_EQUAL(infoResp.status,403,
+				 "Requests to get instance replica info without authentication should be rejected");
+    
+    // try listing instances with invalid authentication
+	infoResp=httpGet(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/ABC/scale?token=00112233-4455-6677-8899-aabbccddeeff");
+	ENSURE_EQUAL(infoResp.status,403,
+				 "Requests to get instance replica info with invalid authentication should be rejected");
+}
+
+TEST(UnauthenticatedInstanceSetReplicas){
+    using namespace httpRequests;
+	TestContext tc;
+
+    // Try to get 
+    auto infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/ABC/scale?replicas=3");
+    ENSURE_EQUAL(infoResp.status,403,
+				 "Requests to get instance replica info without authentication should be rejected");
+    
+    // try listing instances with invalid authentication
+	infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/ABC/scale?token=00112233-4455-6677-8899-aabbccddeeff&replicas=3");
+	ENSURE_EQUAL(infoResp.status,403,
+				 "Requests to get instance replica info with invalid authentication should be rejected");
+}
+
+TEST(FetchAndSetInstanceReplicas){
+    using namespace httpRequests;
+	TestContext tc;
+
+    std::string adminKey=getPortalToken();
+	auto schema=loadSchema(getSchemaDir()+"/InstanceScaleResultSchema.json");
+
+    const std::string groupName="test-fetch-inst-scale";
+	const std::string clusterName="test-get-scale-cluster";
+
+    { // create a VO
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		rapidjson::Value metadata(rapidjson::kObjectType);
+		metadata.AddMember("name", groupName, alloc);
+		metadata.AddMember("scienceField", "Logic", alloc);
+		request.AddMember("metadata", metadata, alloc);
+		auto createResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/groups?token="+adminKey,to_string(request));
+		ENSURE_EQUAL(createResp.status,200,"Group creation request should succeed");
+	}
+
+    { // create a cluster
+		auto kubeConfig = tc.getKubeConfig();
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		rapidjson::Value metadata(rapidjson::kObjectType);
+		metadata.AddMember("name", clusterName, alloc);
+		metadata.AddMember("group", groupName, alloc);
+		metadata.AddMember("owningOrganization", "Department of Labor", alloc);
+		metadata.AddMember("kubeconfig", kubeConfig, alloc);
+		request.AddMember("metadata", metadata, alloc);
+		auto createResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/clusters?token="+adminKey, to_string(request));
+		ENSURE_EQUAL(createResp.status,200,
+					 "Cluster creation request should succeed");
+		ENSURE(!createResp.body.empty());
+	}
+
+    std::string instID;
+	struct cleanupHelper{
+		TestContext& tc;
+		const std::string& id, key;
+		cleanupHelper(TestContext& tc, const std::string& id, const std::string& key):
+		tc(tc),id(id),key(key){}
+		~cleanupHelper(){
+			if(!id.empty())
+				auto delResp=httpDelete(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+id+"?token="+key);
+		}
+	} cleanup(tc,instID,adminKey);
+
+    const std::string application="test-app";
+	const std::string config1="num: 2571008";
+	const std::string config2="thing: foobar";
+
+    { // install app
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		request.AddMember("group", groupName, alloc);
+		request.AddMember("cluster", clusterName, alloc);
+		request.AddMember("tag", "install1", alloc);
+		request.AddMember("configuration", config1+"\n"+config2, alloc);
+		auto instResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/apps/"+application+"?test&token="+adminKey,to_string(request));
+		ENSURE_EQUAL(instResp.status,200,"Application install request should succeed");
+		rapidjson::Document data;
+		data.Parse(instResp.body);
+		if(data.HasMember("metadata") && data["metadata"].IsObject() && data["metadata"].HasMember("id"))
+			instID=data["metadata"]["id"].GetString();
+	}
+
+    { // Get replica info
+        auto infoResp=httpGet(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+instID+"/scale?token="+adminKey);
+        ENSURE_EQUAL(instResp.status,200,"Application get instance scale request should succeed");
+        rapidjson::Document data;
+        data.Parse(infoResp.body);
+        ENSURE_CONFORMS(data,schema);
+        ENSURE_EQUAL(data["deployments"][groupName + "-" + application + "-install1"].GetInt(), 1, "Replica count should be 1 after installation");
+    }
+
+    { // Rescale replica
+        auto infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+instID+"/scale?token="+adminKey+"&replicas=3");
+        ENSURE_EQUAL(instResp.status,200,"Application change instance scale to 3 should succeed");
+        rapidjson::Document data;
+        data.Parse(infoResp.body);
+        ENSURE_CONFORMS(data,schema);
+        ENSURE_EQUAL(data["deployments"][groupName + "-" + application + "-install1"].GetInt(), 3, "Replica count should be 3 after rescaling");
+    }
+
+    { // Rescale replica again!
+        auto infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+instID+"/scale?token="+adminKey+"&replicas=2");
+        ENSURE_EQUAL(instResp.status,200,"Application change instance scale to 2 should succeed");
+        rapidjson::Document data;
+        data.Parse(infoResp.body);
+        ENSURE_CONFORMS(data,schema);
+        ENSURE_EQUAL(data["deployments"][groupName + "-" + application + "-install1"].GetInt(), 2, "Replica count should be 2 after rescaling a second time");
+    }
+}
+
+TEST(UnrelatedUserInstanceReplicas){
+    using namespace httpRequests;
+	TestContext tc;
+
+    std::string adminKey=getPortalToken();
+	auto schema=loadSchema(getSchemaDir()+"/InstanceScaleResultSchema.json");
+
+    const std::string groupName="test-unreluser-fetch-inst-scale";
+	const std::string clusterName="test-get-scale-cluster-unreluser";
+
+    { // create a VO
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		rapidjson::Value metadata(rapidjson::kObjectType);
+		metadata.AddMember("name", groupName, alloc);
+		metadata.AddMember("scienceField", "Biology", alloc);
+		request.AddMember("metadata", metadata, alloc);
+		auto createResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/groups?token="+adminKey,to_string(request));
+		ENSURE_EQUAL(createResp.status,200,"Group creation request should succeed");
+	}
+
+    { // create a cluster
+		auto kubeConfig = tc.getKubeConfig();
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		rapidjson::Value metadata(rapidjson::kObjectType);
+		metadata.AddMember("name", clusterName, alloc);
+		metadata.AddMember("group", groupName, alloc);
+		metadata.AddMember("owningOrganization", "Area 51", alloc);
+		metadata.AddMember("kubeconfig", kubeConfig, alloc);
+		request.AddMember("metadata", metadata, alloc);
+		auto createResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/clusters?token="+adminKey, to_string(request));
+		ENSURE_EQUAL(createResp.status,200,
+					 "Cluster creation request should succeed");
+		ENSURE(!createResp.body.empty());
+	}
+
+    std::string instID;
+	struct cleanupHelper{
+		TestContext& tc;
+		const std::string& id, key;
+		cleanupHelper(TestContext& tc, const std::string& id, const std::string& key):
+		tc(tc),id(id),key(key){}
+		~cleanupHelper(){
+			if(!id.empty())
+				auto delResp=httpDelete(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+id+"?token="+key);
+		}
+	} cleanup(tc,instID,adminKey);
+
+    const std::string application="test-app";
+	const std::string config1="num: 345";
+	const std::string config2="thing: barfoo";
+
+    { // install app
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		request.AddMember("group", groupName, alloc);
+		request.AddMember("cluster", clusterName, alloc);
+		request.AddMember("tag", "install2", alloc);
+		request.AddMember("configuration", config1+"\n"+config2, alloc);
+		auto instResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/apps/"+application+"?test&token="+adminKey,to_string(request));
+		ENSURE_EQUAL(instResp.status,200,"Application install request should succeed");
+		rapidjson::Document data;
+		data.Parse(instResp.body);
+		if(data.HasMember("metadata") && data["metadata"].IsObject() && data["metadata"].HasMember("id"))
+			instID=data["metadata"]["id"].GetString();
+	}
+
+    std::string tok;
+	{ // create an unrelated user
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		rapidjson::Value metadata(rapidjson::kObjectType);
+		metadata.AddMember("name", "Jeff", alloc);
+		metadata.AddMember("email", "jeff@alienhunters.org", alloc);
+		metadata.AddMember("phone", "555-5555", alloc);
+		metadata.AddMember("institution", "Earthling University of Xenobiology", alloc);
+		metadata.AddMember("admin", false, alloc);
+		metadata.AddMember("globusID", "Jeff's Globus ID", alloc);
+		request.AddMember("metadata", metadata, alloc);
+		auto createResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/users?token="+adminKey,to_string(request));
+		ENSURE_EQUAL(createResp.status,200,"User creation request should succeed");
+		rapidjson::Document createData;
+		createData.Parse(createResp.body);
+		tok=createData["metadata"]["access_token"].GetString();
+    }
+
+    { // have the new user attempt to get replica count
+		auto infoResp=httpGet(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+instID+"/scale?token="+tok);
+		ENSURE_EQUAL(infoResp.status,403,
+		             "Requests for instance replica count from users who do not belong to"
+		             " the owning Group should be rejected.");
+	}
+
+    { // have the new user attempt to set replica count
+		auto infoResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+instID+"/scale?token="+tok+"&replicas=3");
+		ENSURE_EQUAL(infoResp.status,403,
+		             "Requests to change replica count from users who do not belong to"
+		             " the owning Group should be rejected.");
+	}
+}


### PR DESCRIPTION
This PR is intended to address Issue https://github.com/slateci/slate-client-server/issues/57

The basic summary of the tests is like so:

- Tests fetching replica count without or with invalid credentials
- Tests scaling replica count without or with invalid credentials
- Tests fetching replica count and changing it multiple times with proper credentials
- Tests fetching replica count and changing it from a user who lacks group membership

Any additional test ideas are more than welcome.