### PR TITLE
Report application version for running instances

### DIFF
--- a/resources/api_specification/InstanceInfoResultSchema.json
+++ b/resources/api_specification/InstanceInfoResultSchema.json
@@ -23,6 +23,9 @@
         "application": {
           "type": "string"
         },
+        "appVersion": {
+          "type": "string"
+        },
         "group": {
           "type": "string"
         },
@@ -34,9 +37,12 @@
         },
         "configuration": {
           "type": "string"
+        },
+        "chartVersion": {
+          "type": "string"
         }
       },
-      "required": ["id","name","application","group","cluster","created","configuration"]
+      "required": ["id","name","application","appVersion","group","cluster","created","configuration","chartVersion"]
     },
     "services": {
       "type": "array",

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -440,18 +440,20 @@ crow::response fetchApplicationInstanceInfo(PersistentStore& store, const crow::
 	 * In the case that there isn't any instances, a 404 would already have been thrown and this code would not be reached.
 	 * As a result we can safely assume that if releaseInfo isn't empty then releaseInfo[0] stores the data we want.
 	 */
-	if (releaseInfo.Size() != 0 && releaseInfo[0].HasMember("app_version") && releaseInfo[0].HasMember("chart")) {
-		// The other members are added in this block to preserve the order dictated by the schema
+	if (releaseInfo.Size() != 0 && releaseInfo[0].HasMember("app_version")) {
 		instanceData.AddMember("appVersion", rapidjson::StringRef(releaseInfo[0]["app_version"].GetString()), alloc);
-		instanceData.AddMember("group", store.getGroup(instance.owningGroup).name, alloc);
-		instanceData.AddMember("cluster", store.getCluster(instance.cluster).name, alloc);
-		instanceData.AddMember("created", rapidjson::StringRef(instance.ctime.c_str()), alloc);
-		instanceData.AddMember("configuration", rapidjson::StringRef(instance.config.c_str()), alloc);
+	} else {
+		instanceData.AddMember("appVersion", "Unknown", alloc);
+	}
+	instanceData.AddMember("group", store.getGroup(instance.owningGroup).name, alloc);
+	instanceData.AddMember("cluster", store.getCluster(instance.cluster).name, alloc);
+	instanceData.AddMember("created", rapidjson::StringRef(instance.ctime.c_str()), alloc);
+	instanceData.AddMember("configuration", rapidjson::StringRef(instance.config.c_str()), alloc);
+	if (releaseInfo.Size() != 0 && releaseInfo[0].HasMember("chart")) {
 		instanceData.AddMember("chartVersion", rapidjson::StringRef(releaseInfo[0]["chart"].GetString()), alloc);
 	} else {
-		return crow::response(500,generateError("app and chart info could not be obtained"));
+		instanceData.AddMember("chartVersion", "Unknown", alloc);
 	}
-	
 	result.AddMember("metadata", instanceData, alloc);
 
 	

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -405,6 +405,14 @@ crow::response fetchApplicationInstanceInfo(PersistentStore& store, const crow::
 	
 	//get information on the owning Group, needed to look up services, etc.
 	const Group group=store.getGroup(instance.owningGroup);
+	if(!group)
+		return crow::response(500,generateError("Invalid Group"));
+
+	//get cluster and kubeconfig path (for app/chart versions)
+	const Cluster cluster=store.getCluster(instance.cluster);
+	if(!cluster)
+		return crow::response(500,generateError("Invalid Cluster"));
+	auto clusterConfig=store.configPathForCluster(cluster.id);
 	
 	//TODO: serialize the instance configuration as JSON
 	rapidjson::Document result(rapidjson::kObjectType);
@@ -419,11 +427,31 @@ crow::response fetchApplicationInstanceInfo(PersistentStore& store, const crow::
 	if(application.find('/')!=std::string::npos && application.find('/')<application.size()-1)
 			application=application.substr(application.find('/')+1);
 	instanceData.AddMember("application", application, alloc);
-	instanceData.AddMember("group", store.getGroup(instance.owningGroup).name, alloc);
-	instanceData.AddMember("cluster", store.getCluster(instance.cluster).name, alloc);
-	instanceData.AddMember("created", rapidjson::StringRef(instance.ctime.c_str()), alloc);
-	instanceData.AddMember("configuration", rapidjson::StringRef(instance.config.c_str()),
-			       alloc);
+	// get helm release info
+	std::vector<std::string> listArgs={"list",
+		"-f","^" + instance.name + "$",
+		"-n",group.namespaceName(),
+		"--output","json",
+	};
+	auto commandResult=runCommand("helm",listArgs,{{"KUBECONFIG",*clusterConfig}});
+	rapidjson::Document releaseInfo;
+	releaseInfo.Parse(commandResult.output.c_str());
+	/* Since both a namespace and name are specified in the above command, we can trust that there is at most one query result.
+	 * In the case that there isn't any instances, a 404 would already have been thrown and this code would not be reached.
+	 * As a result we can safely assume that if releaseInfo isn't empty then releaseInfo[0] stores the data we want.
+	 */
+	if (releaseInfo.Size() != 0 && releaseInfo[0].HasMember("app_version") && releaseInfo[0].HasMember("chart")) {
+		// The other members are added in this block to preserve the order dictated by the schema
+		instanceData.AddMember("appVersion", rapidjson::StringRef(releaseInfo[0]["app_version"].GetString()), alloc);
+		instanceData.AddMember("group", store.getGroup(instance.owningGroup).name, alloc);
+		instanceData.AddMember("cluster", store.getCluster(instance.cluster).name, alloc);
+		instanceData.AddMember("created", rapidjson::StringRef(instance.ctime.c_str()), alloc);
+		instanceData.AddMember("configuration", rapidjson::StringRef(instance.config.c_str()), alloc);
+		instanceData.AddMember("chartVersion", rapidjson::StringRef(releaseInfo[0]["chart"].GetString()), alloc);
+	} else {
+		return crow::response(500,generateError("app and chart info could not be obtained"));
+	}
+	
 	result.AddMember("metadata", instanceData, alloc);
 
 	

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1830,6 +1830,8 @@ void Client::getInstanceInfo(const InstanceOptions& opt){
 		std::cout << formatOutput(body, body,
 		                             {{"Name","/metadata/name"},
 		                              {"Started","/metadata/created",true},
+					      {"App Version", "/metadata/appVersion",false,true},
+					      {"Chart Version", "/metadata/chartVersion",false,true},
 		                              {"Group","/metadata/group"},
 		                              {"Cluster","/metadata/cluster"},
 		                              {"ID","/metadata/id",true}});

--- a/test/TestInstanceInfoFetching.cpp
+++ b/test/TestInstanceInfoFetching.cpp
@@ -97,6 +97,10 @@ TEST(FetchInstanceInfo){
 		ENSURE_EQUAL(metadata["application"].GetString(),application,"Instance application should match");
 		ENSURE_EQUAL(metadata["group"].GetString(),groupName,"Instance application should match");
 		ENSURE_EQUAL(metadata["cluster"].GetString(),clusterName,"Instance cluster should match");
+		ENSURE_EQUAL(metadata["chartVersion"].GetString(), "test-app-0.0.1", "Instance chart version is incorrect");
+		ENSURE_EQUAL(metadata["appVersion"].GetString(), "0.0.1", "Instance app version is incorrect");
+		std::cout << "Chart Version: " << (metadata["chartVersion"].GetString()) << std::endl;
+		std::cout << "App Version: " << (metadata["appVersion"].GetString()) << std::endl;
 		std::cout << "Config: " << (metadata["configuration"].GetString()) << std::endl;
 		ENSURE(std::string(metadata["configuration"].GetString()).find(config1)!=std::string::npos,
 		       "Configuration should contain input data");

--- a/test/test_helm_repo/test-app/Chart.yaml
+++ b/test/test_helm_repo/test-app/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: "v1"
 name: "test-app"
 version: 0.0.1
+appVersion: 0.0.1
 description: "A useless, test application"


### PR DESCRIPTION
This pull request is aimed at addressing issue https://github.com/slateci/slate-client-server/issues/50

`slate instance info` commands will now also report the application and chart versions, which is obtained by querying helm.