### PR TITLE
Eliminate group prefixes in instance names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,6 +513,9 @@ if(BUILD_SERVER)
 
     slate_add_test(test-instance-scaling
         SOURCE_FILES test/TestInstanceScale.cpp)
+
+    slate_add_test(test-instance-duplicates
+        SOURCE_FILES test/TestInstanceDuplicates.cpp)
     
     slate_add_test(test-secret-listing
         SOURCE_FILES test/TestSecretListing.cpp)

--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -499,8 +499,6 @@ private:
 	///return true if the argument mtaches the correct format for a secret ID
 	static bool verifySecretID(const std::string& id);
 	
-	static void filterInstanceNames(rapidjson::Document& json, std::string pointer);
-	
 	std::string endpointPath;
 	std::string apiEndpoint;
 	std::string apiVersion;

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1801,7 +1801,7 @@ void Client::listInstances(const InstanceListOptions& opt){
 	if(response.status==200){
 		rapidjson::Document json;
 		json.Parse(response.body.c_str());
-		filterInstanceNames(json, "/items");
+		//filterInstanceNames(json, "/items");
 		std::cout << formatOutput(json["items"], json,
 		                             columns);
 	}
@@ -1826,7 +1826,7 @@ void Client::getInstanceInfo(const InstanceOptions& opt){
 	if(response.status==200){
 		rapidjson::Document body;
 		body.Parse(response.body.c_str());
-		filterInstanceNames(body,"");
+		//filterInstanceNames(body,"");
 		std::cout << formatOutput(body, body,
 		                             {{"Name","/metadata/name"},
 		                              {"Started","/metadata/created",true},
@@ -2490,7 +2490,7 @@ void Client::retryInstanceCommandWithFixup(void (Client::* command)(const Option
 		bestfits.SetArray();
 		rapidjson::Document::AllocatorType & allocator = bestfits.GetAllocator();
 		json.Parse(response.body.c_str());
-		filterInstanceNames(json, "/items");
+		//filterInstanceNames(json, "/items");
 		
 		
 		// Try to get a better ID/name

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1801,7 +1801,6 @@ void Client::listInstances(const InstanceListOptions& opt){
 	if(response.status==200){
 		rapidjson::Document json;
 		json.Parse(response.body.c_str());
-		//filterInstanceNames(json, "/items");
 		std::cout << formatOutput(json["items"], json,
 		                             columns);
 	}
@@ -1826,7 +1825,6 @@ void Client::getInstanceInfo(const InstanceOptions& opt){
 	if(response.status==200){
 		rapidjson::Document body;
 		body.Parse(response.body.c_str());
-		//filterInstanceNames(body,"");
 		std::cout << formatOutput(body, body,
 		                             {{"Name","/metadata/name"},
 		                              {"Started","/metadata/created",true},
@@ -2492,7 +2490,6 @@ void Client::retryInstanceCommandWithFixup(void (Client::* command)(const Option
 		bestfits.SetArray();
 		rapidjson::Document::AllocatorType & allocator = bestfits.GetAllocator();
 		json.Parse(response.body.c_str());
-		//filterInstanceNames(json, "/items");
 		
 		
 		// Try to get a better ID/name
@@ -2746,23 +2743,4 @@ bool Client::verifySecretID(const std::string& id){
 	if(id.find_first_not_of(base64Chars,7)!=std::string::npos)
 		return false;
 	return true;
-}
-
-void Client::filterInstanceNames(rapidjson::Document& json, std::string pointer){
-	auto filterName=[&json](rapidjson::Value& item){
-		std::string Group=rapidjson::Pointer("/metadata/group").Get(item)->GetString();
-		Group+='-';
-		rapidjson::Value* nameValue=rapidjson::Pointer("/metadata/name").Get(item);
-		std::string name=nameValue->GetString();
-		if(name.find(Group)==0)
-			name.erase(0,Group.size());
-		nameValue->SetString(name.c_str(),name.size(),json.GetAllocator());
-	};
-	rapidjson::Value* item=rapidjson::Pointer(pointer.c_str()).Get(json);
-	if(item->IsArray()){
-		for(auto& item_ : item->GetArray())
-			filterName(item_);
-	}
-	else
-		filterName(*item);
 }

--- a/test/TestInstanceDuplicates.cpp
+++ b/test/TestInstanceDuplicates.cpp
@@ -1,0 +1,208 @@
+#include "test.h"
+
+#include <ServerUtilities.h>
+
+// Duplicates on the same group and cluster should fail
+TEST(TestDuplicatesOnSameClusterAndGroup) {
+    using namespace httpRequests;
+	TestContext tc;
+
+    std::string adminKey=tc.getPortalToken();
+
+    const std::string groupName="test-dup";
+	const std::string clusterName="testcluster1";
+
+    { //create a VO
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		rapidjson::Value metadata(rapidjson::kObjectType);
+		metadata.AddMember("name", groupName, alloc);
+		metadata.AddMember("scienceField", "Physics", alloc);
+		request.AddMember("metadata", metadata, alloc);
+		auto createResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/groups?token="+adminKey,to_string(request));
+		ENSURE_EQUAL(createResp.status,200,"Group creation request should succeed");
+	}
+
+    { //create a cluster
+		auto kubeConfig = tc.getKubeConfig();
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		rapidjson::Value metadata(rapidjson::kObjectType);
+		metadata.AddMember("name", clusterName, alloc);
+		metadata.AddMember("group", groupName, alloc);
+		metadata.AddMember("owningOrganization", "Black Mesa", alloc);
+		metadata.AddMember("kubeconfig", kubeConfig, alloc);
+		request.AddMember("metadata", metadata, alloc);
+		auto createResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/clusters?token="+adminKey, to_string(request));
+		ENSURE_EQUAL(createResp.status,200,
+					 "Cluster creation request should succeed");
+		ENSURE(!createResp.body.empty());
+	}
+
+    std::string instID;
+	struct cleanupHelper{
+		TestContext& tc;
+		const std::string& id, key;
+		cleanupHelper(TestContext& tc, const std::string& id, const std::string& key):
+		tc(tc),id(id),key(key){}
+		~cleanupHelper(){
+			if(!id.empty())
+				auto delResp=httpDelete(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+id+"?token="+key);
+		}
+	} cleanup(tc,instID,adminKey);
+
+    const std::string application="test-app";
+	const std::string config1="num: 22";
+	const std::string config2="thing: stuff";
+	{ //install a thing
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		request.AddMember("group", groupName, alloc);
+		request.AddMember("cluster", clusterName, alloc);
+		request.AddMember("tag", "install1", alloc);
+		request.AddMember("configuration", config1+"\n"+config2, alloc);
+		auto instResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/apps/"+application+"?test&token="+adminKey,to_string(request));
+		ENSURE_EQUAL(instResp.status,200,"Application install request should succeed");
+        rapidjson::Document data;
+		data.Parse(instResp.body);
+		if(data.HasMember("metadata") && data["metadata"].IsObject() && data["metadata"].HasMember("id"))
+			instID=data["metadata"]["id"].GetString();
+	}
+
+	{ // Try to install another thing
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		request.AddMember("group", groupName, alloc);
+		request.AddMember("cluster", clusterName, alloc);
+		request.AddMember("tag", "install1", alloc);
+		request.AddMember("configuration", config1+"\n"+config2, alloc);
+		auto instResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/apps/"+application+"?test&token="+adminKey,to_string(request));
+		ENSURE_EQUAL(instResp.status,400,"Duplicate app on the same group & cluster should fail");
+	}
+}
+
+// Duplicates on the same cluster but different groups should succeed
+TEST(TestDuplicatesOnSameClusterDiffGroups) {
+    using namespace httpRequests;
+	TestContext tc;
+
+    std::string adminKey=tc.getPortalToken();
+
+    const std::string groupName1="test-dup1";
+    const std::string groupName2="test-dup2";
+	const std::string clusterName="testcluster2";
+
+    { //create a VO
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		rapidjson::Value metadata(rapidjson::kObjectType);
+		metadata.AddMember("name", groupName1, alloc);
+		metadata.AddMember("scienceField", "Biology", alloc);
+		request.AddMember("metadata", metadata, alloc);
+		auto createResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/groups?token="+adminKey,to_string(request));
+		ENSURE_EQUAL(createResp.status,200,"First group creation request should succeed");
+	}
+
+    std::string group2ID;
+    { //create another VO
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		rapidjson::Value metadata(rapidjson::kObjectType);
+		metadata.AddMember("name", groupName2, alloc);
+		metadata.AddMember("scienceField", "Chemistry", alloc);
+		request.AddMember("metadata", metadata, alloc);
+		auto createResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/groups?token="+adminKey,to_string(request));
+		ENSURE_EQUAL(createResp.status,200,"Second group creation request should succeed");
+        rapidjson::Document data;
+		data.Parse(createResp.body);
+		if(data.HasMember("metadata") && data["metadata"].IsObject() && data["metadata"].HasMember("id"))
+			group2ID=data["metadata"]["id"].GetString();
+	}
+
+    std::string clustID;
+    { //create a cluster
+		auto kubeConfig = tc.getKubeConfig();
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		rapidjson::Value metadata(rapidjson::kObjectType);
+		metadata.AddMember("name", clusterName, alloc);
+		metadata.AddMember("group", groupName1, alloc);
+		metadata.AddMember("owningOrganization", "Ocean Research Project", alloc);
+		metadata.AddMember("kubeconfig", kubeConfig, alloc);
+		request.AddMember("metadata", metadata, alloc);
+		auto createResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/clusters?token="+adminKey, to_string(request));
+		ENSURE_EQUAL(createResp.status,200,
+					 "Cluster creation request should succeed");
+		ENSURE(!createResp.body.empty());
+        rapidjson::Document data;
+        data.Parse(createResp.body);
+        if(data.HasMember("metadata") && data["metadata"].IsObject() && data["metadata"].HasMember("id"))
+			clustID=data["metadata"]["id"].GetString();
+	}
+
+    { //give other group access to other cluster
+        auto allowResp=httpPut(tc.getAPIServerURL()+"/"+currentAPIVersion+"/clusters/" + clustID + "/allowed_groups/" + group2ID+ "?token="+ adminKey, "");
+        ENSURE_EQUAL(allowResp.status,200,
+					 "Second group should be given access to cluster");
+    }
+
+    std::string instID;
+    std::string instID2;
+	struct cleanupHelper{
+		TestContext& tc;
+		const std::string& id, key;
+		cleanupHelper(TestContext& tc, const std::string& id, const std::string& key):
+		tc(tc),id(id),key(key){}
+		~cleanupHelper(){
+			if(!id.empty())
+				auto delResp=httpDelete(tc.getAPIServerURL()+"/"+currentAPIVersion+"/instances/"+id+"?token="+key);
+		}
+	} cleanup(tc,instID,adminKey);
+    
+    cleanupHelper cleanup2(tc, instID2,adminKey);
+    
+    const std::string application="test-app";
+	const std::string config1="num: 22";
+	const std::string config2="thing: stuff";
+    const std::string config3="num: 23";
+	const std::string config4="thing: ooer";
+
+    { //install a thing
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		request.AddMember("group", groupName1, alloc);
+		request.AddMember("cluster", clusterName, alloc);
+		request.AddMember("tag", "install1", alloc);
+		request.AddMember("configuration", config1+"\n"+config2, alloc);
+		auto instResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/apps/"+application+"?test&token="+adminKey,to_string(request));
+		ENSURE_EQUAL(instResp.status,200,"Application install request should succeed");
+        rapidjson::Document data;
+		data.Parse(instResp.body);
+		if(data.HasMember("metadata") && data["metadata"].IsObject() && data["metadata"].HasMember("id"))
+			instID=data["metadata"]["id"].GetString();
+	}
+
+    { //install another thing
+		rapidjson::Document request(rapidjson::kObjectType);
+		auto& alloc = request.GetAllocator();
+		request.AddMember("apiVersion", currentAPIVersion, alloc);
+		request.AddMember("group", groupName2, alloc);
+		request.AddMember("cluster", clusterName, alloc);
+		request.AddMember("tag", "install1", alloc);
+		request.AddMember("configuration", config3+"\n"+config4, alloc);
+		auto instResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/apps/"+application+"?test&token="+adminKey,to_string(request));
+		ENSURE_EQUAL(instResp.status,200,"Duplicate application install request should succeed");
+        rapidjson::Document data;
+		data.Parse(instResp.body);
+		if(data.HasMember("metadata") && data["metadata"].IsObject() && data["metadata"].HasMember("id"))
+			instID2=data["metadata"]["id"].GetString();
+	}
+}


### PR DESCRIPTION
These changes aim to address issue https://github.com/slateci/slate-client-server/issues/83

With helm v3+ release names may be shared across namespaces. As such we no longer need group prefixes added to instance names. These changes reflect that and include unit tests to ensure that unexpected behavior does not occur.