### PR TITLE
Adding user management commands

### DIFF
--- a/include/UserCommands.h
+++ b/include/UserCommands.h
@@ -11,6 +11,7 @@
 crow::response listUsers(PersistentStore& store, const crow::request& req);
 crow::response createUser(PersistentStore& store, const crow::request& req);
 crow::response getUserInfo(PersistentStore& store, const crow::request& req, const std::string uID);
+crow::response whoAreThey(PersistentStore& store, const crow::request& req);
 crow::response updateUser(PersistentStore& store, const crow::request& req, const std::string uID);
 crow::response deleteUser(PersistentStore& store, const crow::request& req, const std::string uID);
 crow::response listUsergroups(PersistentStore& store, const crow::request& req, const std::string uID);
@@ -21,6 +22,4 @@ crow::response removeUserFromGroup(PersistentStore& store, const crow::request& 
 crow::response findUser(PersistentStore& store, const crow::request& req);
 crow::response replaceUserToken(PersistentStore& store, const crow::request& req,
                                 const std::string uID);
-crow::response whoAreThey(PersistentStore& store, const crow::request& req);
-
 #endif //SLATE_USER_COMMANDS_H

--- a/include/UserCommands.h
+++ b/include/UserCommands.h
@@ -21,5 +21,6 @@ crow::response removeUserFromGroup(PersistentStore& store, const crow::request& 
 crow::response findUser(PersistentStore& store, const crow::request& req);
 crow::response replaceUserToken(PersistentStore& store, const crow::request& req,
                                 const std::string uID);
+crow::response whoAreThey(PersistentStore& store, const crow::request& req);
 
 #endif //SLATE_USER_COMMANDS_H

--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -360,7 +360,7 @@ public:
 
 	void getUserInfo(const UserOptions& opt);
 
-	void listUsers();
+	void listUsers(const UserOptions& opt);
 
 	void listUserGroups(const UserOptions& opt);
 

--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -338,6 +338,8 @@ public:
 
 	void scaleInstance(const InstanceScaleOptions& opt);
 
+	void fetchCurrentProfile();
+
 	void listSecrets(const SecretListOptions& opt);
 
 	void getSecretInfo(const SecretOptions& opt);

--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -224,6 +224,24 @@ struct SecretCopyOptions{
 	std::string sourceID;
 };
 
+struct UserOptions{
+	std::string id;
+	std::string group;
+};
+
+struct CreateUserOptions{
+	std::string globID;
+	std::string name;
+	std::string email;
+	std::string phone;
+	std::string institution;
+	bool admin;
+};
+
+struct UpdateUserOptions: public CreateUserOptions{
+	std::string id;
+};
+
 struct SecretDeleteOptions : public SecretOptions{
 	bool force;
 	bool assumeYes;
@@ -340,6 +358,24 @@ public:
 
 	void fetchCurrentProfile();
 
+	void getUserInfo(const UserOptions& opt);
+
+	void listUsers();
+
+	void listUserGroups(const UserOptions& opt);
+
+	void createUser(const CreateUserOptions& opt);
+
+	void removeUser(const UserOptions& opt);
+
+	void updateUser(const UpdateUserOptions& opt);
+
+	void addUserToGroup(const UserOptions& opt);
+
+	void removeUserFromGroup(const UserOptions& opt);
+
+	void updateUserToken(const UserOptions& opt);
+
 	void listSecrets(const SecretListOptions& opt);
 
 	void getSecretInfo(const SecretOptions& opt);
@@ -389,6 +425,8 @@ private:
 	std::string getDefaultCredFilePath();
 	
 	std::string fetchStoredCredentials();
+
+	void updateStoredCredentials(std::string token);
 	
 	std::string getToken();
 	
@@ -496,9 +534,13 @@ private:
 	std::string formatOutput(const rapidjson::Value& jdata, const rapidjson::Value& original,
 				 const std::vector<columnSpec>& columns) const;
 	
-	///return true if the argument mtaches the correct format for an instance ID
+	///return true if the argument matches the correct format for an instance ID
 	static bool verifyInstanceID(const std::string& id);
-	///return true if the argument mtaches the correct format for a secret ID
+	///return true if the argument matches the correct format for a user ID
+	static bool verifyUserID(const std::string& id);
+	///return true if the argument matches the correct format for a group ID
+	static bool verifyGroupID(const std::string& id);
+	///return true if the argument matches the correct format for a secret ID
 	static bool verifySecretID(const std::string& id);
 	
 	std::string endpointPath;

--- a/resources/api_specification/slate.raml
+++ b/resources/api_specification/slate.raml
@@ -311,6 +311,30 @@ version: v1alpha3
                     "kind": "Error",
                     "message": "User not found"
                   }
+/whoami:
+  get:
+    description: Fetch requester's profile
+    queryParameters: 
+      token:
+        displayName: AccessToken
+        type: string
+        description: User's authentication token
+        required: true
+    responses: 
+      200:
+        description: Obtained user profile
+        body:
+          application/json: !include UserInfoResultSchema.json
+      403:
+        description: Authentication/authorization error
+        body:
+          application/json:
+            type: !include ErrorResultSchema.json
+            example: |
+              {
+                "kind": "Error",
+                "message": "Not authorized"
+              }
 /find_user:
   get:
     description: Look up a user account by globus ID

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -440,18 +440,20 @@ crow::response fetchApplicationInstanceInfo(PersistentStore& store, const crow::
 	 * In the case that there isn't any instances, a 404 would already have been thrown and this code would not be reached.
 	 * As a result we can safely assume that if releaseInfo isn't empty then releaseInfo[0] stores the data we want.
 	 */
-	if (releaseInfo.Size() != 0 && releaseInfo[0].HasMember("app_version") && releaseInfo[0].HasMember("chart")) {
-		// The other members are added in this block to preserve the order dictated by the schema
+	if (releaseInfo.Size() != 0 && releaseInfo[0].HasMember("app_version")) {
 		instanceData.AddMember("appVersion", rapidjson::StringRef(releaseInfo[0]["app_version"].GetString()), alloc);
-		instanceData.AddMember("group", store.getGroup(instance.owningGroup).name, alloc);
-		instanceData.AddMember("cluster", store.getCluster(instance.cluster).name, alloc);
-		instanceData.AddMember("created", rapidjson::StringRef(instance.ctime.c_str()), alloc);
-		instanceData.AddMember("configuration", rapidjson::StringRef(instance.config.c_str()), alloc);
+	} else {
+		instanceData.AddMember("appVersion", "Unknown", alloc);
+	}
+	instanceData.AddMember("group", store.getGroup(instance.owningGroup).name, alloc);
+	instanceData.AddMember("cluster", store.getCluster(instance.cluster).name, alloc);
+	instanceData.AddMember("created", rapidjson::StringRef(instance.ctime.c_str()), alloc);
+	instanceData.AddMember("configuration", rapidjson::StringRef(instance.config.c_str()), alloc);
+	if (releaseInfo.Size() != 0 && releaseInfo[0].HasMember("chart")) {
 		instanceData.AddMember("chartVersion", rapidjson::StringRef(releaseInfo[0]["chart"].GetString()), alloc);
 	} else {
-		return crow::response(500,generateError("app and chart info could not be obtained"));
+		instanceData.AddMember("chartVersion", "Unknown", alloc);
 	}
-	
 	result.AddMember("metadata", instanceData, alloc);
 
 	

--- a/src/UserCommands.cpp
+++ b/src/UserCommands.cpp
@@ -456,3 +456,36 @@ crow::response replaceUserToken(PersistentStore& store, const crow::request& req
 	
 	return crow::response(to_string(result));
 }
+
+crow::response whoAreThey(PersistentStore& store, const crow::request& req) {
+	const User user=authenticateUser(store, req.url_params.get("token"));
+	log_info(user << " requested information about themselves from " << req.remote_endpoint);
+	// this check should never fail, better safe than sorry
+	if(!user)
+		return crow::response(403,generateError("Not authorized"));
+
+	rapidjson::Document result(rapidjson::kObjectType);
+	rapidjson::Document::AllocatorType& alloc = result.GetAllocator();
+	
+	result.AddMember("apiVersion", "v1alpha3", alloc);
+	result.AddMember("kind", "User", alloc);
+	rapidjson::Value metadata(rapidjson::kObjectType);
+	metadata.AddMember("id", rapidjson::StringRef(user.id.c_str()), alloc);
+	metadata.AddMember("name", rapidjson::StringRef(user.name.c_str()), alloc);
+	metadata.AddMember("email", rapidjson::StringRef(user.email.c_str()), alloc);
+	metadata.AddMember("phone", rapidjson::StringRef(user.phone.c_str()), alloc);
+	metadata.AddMember("institution", rapidjson::StringRef(user.institution.c_str()), alloc);
+	metadata.AddMember("access_token", rapidjson::StringRef(user.token.c_str()), alloc);
+	metadata.AddMember("admin", user.admin, alloc);
+	rapidjson::Value groupMemberships(rapidjson::kArrayType);
+	std::vector<std::string> groupMembershipList = store.getUserGroupMemberships(user.id,true);
+	for (auto group : groupMembershipList) {
+		rapidjson::Value entry(rapidjson::kStringType);
+		entry.SetString(group, alloc);
+		groupMemberships.PushBack(entry, alloc);
+	}
+	metadata.AddMember("groups", groupMemberships, alloc);
+	result.AddMember("metadata", metadata, alloc);
+	
+	return crow::response(to_string(result));
+}

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -2211,6 +2211,31 @@ void Client::scaleInstance(const InstanceScaleOptions& opt){
 	}
 }
 
+void Client::fetchCurrentProfile(){
+	std::string url=makeURL("whoami");
+
+	auto response=httpRequests::httpGet(url,defaultOptions());
+
+	if(response.status==200){
+		rapidjson::Document body;
+		body.Parse(response.body.c_str());
+
+		std::cout << formatOutput(body, body, {{"Name", "/metadata/name",true},
+											   {"ID", "/metadata/id",true},
+											   {"Email","/metadata/email",true},
+											   {"Phone","/metadata/phone",true}});
+		std::cout << formatOutput(body, body, {{"Institution", "/metadata/institution"},
+											   {"Token", "/metadata/access_token",true},
+											   {"Admin", "/metadata/admin"}});
+		std::cout << formatOutput(body["metadata"]["groups"], body,
+		                             {{"Groups", "", true}});
+	} else {
+		std::cerr << "Failed to fetch your profile";
+		showError(response.body);
+		throw OperationFailed();
+	}
+}
+
 void Client::listSecrets(const SecretListOptions& opt){
 	ProgressToken progress(pman_,"Fetching secret list...");
 	std::string url=makeURL("secrets") + "&group="+opt.group;

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -536,7 +536,7 @@ void registerUserDelete(CLI::App& parent, Client& client) {
 void registerUserUpdate(CLI::App& parent, Client& client) {
 	auto updateOpt = std::make_shared<UpdateUserOptions>();
 	auto upd = parent.add_subcommand("update", "Update user profile");
-	upd->add_option("user", updateOpt->id, "ID of the user")->required();
+	upd->add_option("user", updateOpt->id, "ID of the user (if not included this will update your own profile)");
 	upd->add_option("--name", updateOpt->name, "Name of the user");
 	upd->add_option("--email", updateOpt->email, "Email of the user");
 	upd->add_option("--phone", updateOpt->phone, "Phone of the user");
@@ -548,7 +548,7 @@ void registerAddUserToGroup(CLI::App& parent, Client& client) {
 	auto membrOpt = std::make_shared<UserOptions>();
 	auto groupOp = parent.add_subcommand("add-to-group", "Add user to group");
 	groupOp->add_option("user", membrOpt->id, "ID of the user")->required();
-	groupOp->add_option("group", membrOpt->group, "ID of the group to be added to")->required();
+	groupOp->add_option("group", membrOpt->group, "ID or name of the group to be added to")->required();
 	groupOp->callback([&client, membrOpt](){ client.addUserToGroup(*membrOpt); });
 }
 
@@ -556,14 +556,14 @@ void registerRemoveUserFromGroup(CLI::App& parent, Client& client) {
 	auto membrOpt = std::make_shared<UserOptions>();
 	auto groupOp = parent.add_subcommand("remove-from-group", "Remove user from group");
 	groupOp->add_option("user", membrOpt->id, "ID of the user")->required();
-	groupOp->add_option("group", membrOpt->group, "ID of the group to be removed from")->required();
+	groupOp->add_option("group", membrOpt->group, "ID or name of the group to be removed from")->required();
 	groupOp->callback([&client, membrOpt](){ client.removeUserFromGroup(*membrOpt); });
 }
 
 void registerUserUpdateToken(CLI::App& parent, Client& client) {
 	auto membrOpt = std::make_shared<UserOptions>();
 	auto tokOp = parent.add_subcommand("replace-token", "Generate a new token for a user");
-	tokOp->add_option("user", membrOpt->id, "ID of the user")->required();
+	tokOp->add_option("user", membrOpt->id, "ID of the user (if not included this will update your own profile)");
 	tokOp->callback([&client, membrOpt](){ client.updateUserToken(*membrOpt); });
 }
 

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -489,6 +489,11 @@ void registerSecretCommands(CLI::App& parent, Client& client){
 	registerSecretDelete(*secr, client);
 }
 
+void registerWhoAmI(CLI::App& parent, Client& client) {
+	auto who = parent.add_subcommand("whoami", "Fetch current user credentials");
+	who->callback([&client](){ client.fetchCurrentProfile(); });
+}
+
 void registerCommonOptions(CLI::App& parent, Client& client){
 	parent.add_option("--orderBy", client.orderBy, "the name of a column in the JSON output"
 			"by which to order the table printed to stdout.");
@@ -556,7 +561,7 @@ int main(int argc, char* argv[]){
 		registerInstanceCommands(slate,client);
 		registerSecretCommands(slate,client);
 		registerCommonOptions(slate,client);
-		
+		registerWhoAmI(slate,client);
 		startReaper();
 		CLI11_PARSE(slate, argc, argv);
 	}

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -494,6 +494,93 @@ void registerWhoAmI(CLI::App& parent, Client& client) {
 	who->callback([&client](){ client.fetchCurrentProfile(); });
 }
 
+void registerUserList(CLI::App& parent, Client& client) {
+	auto usrlist = parent.add_subcommand("list", "List SLATE users on cluster");
+	usrlist->callback([&client](){ client.listUsers(); });
+}
+
+void registerUserInfo(CLI::App& parent, Client& client) {
+	auto infoOpt = std::make_shared<UserOptions>();
+	auto info = parent.add_subcommand("info", "Get info about a SLATE user");
+	info->add_option("user", infoOpt->id, "ID of the user being queried")->required();
+	info->callback([&client, infoOpt](){ client.getUserInfo(*infoOpt); });
+}
+
+void registerUserGroupList(CLI::App& parent, Client& client) {
+	auto gplOpt = std::make_shared<UserOptions>();
+	auto grouplist = parent.add_subcommand("groups", "List groups of SLATE user");
+	grouplist->add_option("user", gplOpt->id, "ID of the user being queried")->required();
+	grouplist->callback([&client, gplOpt](){ client.listUserGroups(*gplOpt); });
+}
+
+// Not used currently
+// void registerUserAdd(CLI::App& parent, Client& client) {
+// 	auto usrCreateOpt = std::make_shared<CreateUserOptions>();
+// 	auto usrcreate = parent.add_subcommand("create", "Create a new user");
+// 	usrCreate->add_option("--globus", usrCreateOpt->globID, "Globus ID of the user")->required();
+// 	usrCreate->add_option("--name", usrCreateOpt->name, "Name of the user")->required();
+// 	usrCreate->add_option("--email", usrCreateOpt->email, "Email of the user")->required();
+// 	usrCreate->add_option("--phone", usrCreateOpt->phone, "Phone of the user")->required();
+// 	usrCreate->add_option("--institution", usrCreateOpt->institution, "Institution of the user")->required();
+// 	usrCreate->add_flag("-a,--admin", usrCreateOpt->admin, "This user is an administrator");
+// 	usrCreate->callback();
+// }
+
+void registerUserDelete(CLI::App& parent, Client& client) {
+	auto usrDeleteOpt = std::make_shared<UserOptions>();
+	auto del = parent.add_subcommand("delete", "Delete slate user");
+	del->add_option("user", usrDeleteOpt->id, "ID of the user being deleted")->required();
+	del->callback([&client, usrDeleteOpt](){ client.removeUser(*usrDeleteOpt); });
+}
+
+void registerUserUpdate(CLI::App& parent, Client& client) {
+	auto updateOpt = std::make_shared<UpdateUserOptions>();
+	auto upd = parent.add_subcommand("update", "Update user profile");
+	upd->add_option("user", updateOpt->id, "ID of the user")->required();
+	upd->add_option("--name", updateOpt->name, "Name of the user");
+	upd->add_option("--email", updateOpt->email, "Email of the user");
+	upd->add_option("--phone", updateOpt->phone, "Phone of the user");
+	upd->add_option("--institution", updateOpt->institution, "Institution of the user");
+	upd->callback([&client, updateOpt](){ client.updateUser(*updateOpt); });
+}
+
+void registerAddUserToGroup(CLI::App& parent, Client& client) {
+	auto membrOpt = std::make_shared<UserOptions>();
+	auto groupOp = parent.add_subcommand("add-to-group", "Add user to group");
+	groupOp->add_option("user", membrOpt->id, "ID of the user")->required();
+	groupOp->add_option("group", membrOpt->group, "ID of the group to be added to")->required();
+	groupOp->callback([&client, membrOpt](){ client.addUserToGroup(*membrOpt); });
+}
+
+void registerRemoveUserFromGroup(CLI::App& parent, Client& client) {
+	auto membrOpt = std::make_shared<UserOptions>();
+	auto groupOp = parent.add_subcommand("remove-from-group", "Remove user from group");
+	groupOp->add_option("user", membrOpt->id, "ID of the user")->required();
+	groupOp->add_option("group", membrOpt->group, "ID of the group to be removed from")->required();
+	groupOp->callback([&client, membrOpt](){ client.removeUserFromGroup(*membrOpt); });
+}
+
+void registerUserUpdateToken(CLI::App& parent, Client& client) {
+	auto membrOpt = std::make_shared<UserOptions>();
+	auto tokOp = parent.add_subcommand("replace-token", "Generate a new token for a user");
+	tokOp->add_option("user", membrOpt->id, "ID of the user")->required();
+	tokOp->callback([&client, membrOpt](){ client.updateUserToken(*membrOpt); });
+}
+
+void registerUserCommands(CLI::App& parent, Client& client) {
+	auto usrcmd = parent.add_subcommand("user", "Manage SLATE users");
+	usrcmd->require_subcommand();
+	registerUserList(*usrcmd, client);
+	registerUserInfo(*usrcmd, client);
+	registerUserGroupList(*usrcmd, client);
+	//registerUserAdd(*usrcmd, client);
+	registerUserDelete(*usrcmd, client);
+	registerUserUpdate(*usrcmd, client);
+	registerAddUserToGroup(*usrcmd, client);
+	registerRemoveUserFromGroup(*usrcmd, client);
+	registerUserUpdateToken(*usrcmd, client);
+}
+
 void registerCommonOptions(CLI::App& parent, Client& client){
 	parent.add_option("--orderBy", client.orderBy, "the name of a column in the JSON output"
 			"by which to order the table printed to stdout.");
@@ -562,6 +649,7 @@ int main(int argc, char* argv[]){
 		registerSecretCommands(slate,client);
 		registerCommonOptions(slate,client);
 		registerWhoAmI(slate,client);
+		registerUserCommands(slate,client);
 		startReaper();
 		CLI11_PARSE(slate, argc, argv);
 	}

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -495,8 +495,10 @@ void registerWhoAmI(CLI::App& parent, Client& client) {
 }
 
 void registerUserList(CLI::App& parent, Client& client) {
+	auto lOpt = std::make_shared<UserOptions>();
 	auto usrlist = parent.add_subcommand("list", "List SLATE users on cluster");
-	usrlist->callback([&client](){ client.listUsers(); });
+	usrlist->add_option("--group", lOpt->group, "Group filter (name or ID)");
+	usrlist->callback([&client, lOpt](){ client.listUsers(*lOpt); });
 }
 
 void registerUserInfo(CLI::App& parent, Client& client) {

--- a/src/slate_service.cpp
+++ b/src/slate_service.cpp
@@ -446,6 +446,8 @@ int main(int argc, char* argv[]){
 	  [&](const crow::request& req, const std::string& uID){ return replaceUserToken(store,req,uID); });
 	CROW_ROUTE(server, "/v1alpha3/find_user").methods("GET"_method)(
 	  [&](const crow::request& req){ return findUser(store,req); });
+	CROW_ROUTE(server, "/v1alpha3/whoami").methods("GET"_method)(
+	  [&](const crow::request& req){ return whoAreThey(store,req); });
 	
 	// == Cluster commands ==
 	CROW_ROUTE(server, "/v1alpha3/clusters").methods("GET"_method)(


### PR DESCRIPTION
This pull request is aimed at addressing issue https://github.com/slateci/slate-client-server/issues/78

My changes allow someone to do the following through the CLI:
- list users `slate user list`
- fetch their own profile `slate whoami`
- request the info of other users `slate user info <ID>`
- update a user profile `slate user update <ID>`
- add user to a group `slate user add-to-group <uID> <gID>`
- remove a user from a group `slate user remove-from-group <uID> <gID>`
- list the groups a user belongs to `slate user groups <uID>`
- delete users `slate user delete <uID>`
- Renew a user's access token `slate user replace-token <uID>`

This pull request includes changes that would make a good starting point for allowing users to be created through the CLI, however does not support such a function directly

Here `<uID>` refers to a user ID, and `<gID>` refers to a group ID. Open to any revision suggestions