### PR TITLE
Report Node Addresses

### DIFF
--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -71,6 +71,7 @@ struct ClusterListOptions{
 
 struct ClusterInfoOptions{
 	std::string clusterName;
+	bool all_nodes;
 };
 
 struct ClusterCreateOptions{

--- a/resources/api_specification/ClusterInfoResultSchema.json
+++ b/resources/api_specification/ClusterInfoResultSchema.json
@@ -92,8 +92,37 @@
           "required": ["name","isDefault","description","priority"]
         }
       },
+      "masterAddress": {
+        "type": "string"
+      },
+      "nodes": {
+        "type": "array",
+        "items": {
+          "type": "object"
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "addresses": {
+              "type": "array",
+              "items": {
+                "type": "object"
+                "properties": {
+                  "addressType": {
+                    "type" : "string",
+                    "enum" : ["ExternalIP", "InternalIP"]
+                  },
+                  "address": {
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     },
-    "required": ["name","id","owningGroup","owningOrganization","location","hasMonitoring","storageClasses","priorityClasses"]
+    "required": ["name","id","owningGroup","owningOrganization","location","hasMonitoring","storageClasses","priorityClasses","masterAddress"]
   },
   "required": ["apiVersion","kind","metadata"]
 }

--- a/resources/api_specification/slate.raml
+++ b/resources/api_specification/slate.raml
@@ -450,6 +450,11 @@ version: v1alpha3
           type: string
           description: User's authentication token
           required: true
+        nodes:
+          displayName: Nodes
+          type: boolean
+          description: List all nodes in cluster
+          required: false
       responses:
         200:
           description: Success

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1290,6 +1290,7 @@ void Client::listClusters(const ClusterListOptions& opt){
 
 void Client::getClusterInfo(const ClusterInfoOptions& opt){
 	auto url = makeURL("clusters/"+opt.clusterName);
+	if (opt.all_nodes) url = url + "&nodes";
 	ProgressToken progress(pman_,"Fetching cluster info...");
 	auto response=httpRequests::httpGet(url,defaultOptions());
 	if(response.status==200){
@@ -1299,6 +1300,7 @@ void Client::getClusterInfo(const ClusterInfoOptions& opt){
 		                          {{"Name", "/metadata/name"},
 		                           {"Admin","/metadata/owningGroup"},
 		                           {"Owner","/metadata/owningOrganization"},
+								   {"Server Address", "/metadata/masterAddress", false, true},
 		                           {"ID", "/metadata/id", true}
 		                          });
 		if(clientShouldPrintOnlyJson()){return;}
@@ -1326,6 +1328,14 @@ void Client::getClusterInfo(const ClusterInfoOptions& opt){
 			                          {{"Name","/name"},{"Default","/isDefault"},
 			                           {"Priority","/priority"},
 			                           {"Description","/description",true,true}});
+		}
+		if(json["metadata"].HasMember("nodes") && json["metadata"]["nodes"].IsArray()
+		  && json["metadata"]["nodes"].GetArray().Size()>0){
+			std::cout << "\nNode Address Information:" << std::endl;
+			for (auto& node : json["metadata"]["nodes"].GetArray()) {
+				std::cout << "---- Node: " << node["name"].GetString() << std::endl;
+				std::cout << formatOutput(node["addresses"], node, {{"Address", "/address"},{"Type", "/addressType"}});
+			}
 		}
 	}
 	else{

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -94,8 +94,9 @@ void registerClusterList(CLI::App& parent, Client& client){
 void registerClusterInfo(CLI::App& parent, Client& client){
     auto clusterInfoOpt = std::make_shared<ClusterInfoOptions>();
     auto info = parent.add_subcommand("info", "Get information about a cluster");
-    info->callback([&client, clusterInfoOpt](){ client.getClusterInfo(*clusterInfoOpt); });
-    info->add_option("cluster-name", clusterInfoOpt->clusterName, "The name or ID of the cluster to look up")->required(); 
+    info->add_option("cluster-name", clusterInfoOpt->clusterName, "The name or ID of the cluster to look up")->required();
+	info->add_flag("--all-nodes", clusterInfoOpt->all_nodes, "Include the IP of every node in this query");
+	info->callback([&client, clusterInfoOpt](){ client.getClusterInfo(*clusterInfoOpt); });
 }
 
 void registerClusterCreate(CLI::App& parent, Client& client){


### PR DESCRIPTION
This PR is aimed at addressing issues https://github.com/slateci/slate-client-server/issues/70 and https://github.com/slateci/slate-client-server/issues/42

The changes essentially are like so:

`slate cluster info <cID>` will now have an additional column in the first table `Server Address` which provides the address of the API Server as provided by the kubeconfig. Typically this is the same as the master node address and hence is why this is being used instead.

An optional flag has also been added to the `slate cluster info` command, `--all-nodes` in which the address of every node in the cluster may be queried. Each node is listed along with every internal/external IP address for the node, if available. Currently, this does not support the automatic filtering of private addresses but could be made to do so relatively easily (although I may not have time to get around to those changes).