### PR TITLE
[WIP] Report node's external IP when using nodePort, if available. 

### DIFF
--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -165,14 +165,14 @@ std::multimap<std::string,ServiceInterface> getServices(const SharedFileHandle& 
 			if(podData["items"][0]["status"].HasMember("hostIP")){
 				// now we should get the node info, to see if it has a ExternalIP which we ought to preferentially use
 				if(podData["items"][0]["spec"].HasMember("nodeName")) {
-					auto nodename=podData["Items"][0]["spec"]["nodeName"].GetString();
+					auto nodename=podData["items"][0]["spec"]["nodeName"].GetString();
 
 					t1 = high_resolution_clock::now();
 					auto nodeResult=kubernetes::kubectl(*configPath,{"get","node",nodename,"-o=json"});
 					t2 = high_resolution_clock::now();
 					log_info("kubectl get node completed in " << duration_cast<duration<double>>(t2-t1).count() << " seconds");
 					if(nodeResult.status){
-						log_error("kubectl get node " << nodename << << " failed: " << nodeResult.error);
+						log_error("kubectl get node " << nodename << " failed: " << nodeResult.error);
 						continue;
 					}
 
@@ -188,7 +188,7 @@ std::multimap<std::string,ServiceInterface> getServices(const SharedFileHandle& 
 						continue;
 					}
 
-					if(nodeData.HasMember("status"){
+					if(nodeData.HasMember("status")){
 						for (auto& addr : nodeData["status"]["addresses"].GetArray()) {
 							std::string addrType(addr["type"].GetString());
 							// assume that externalIP won't show up more than once

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -162,10 +162,45 @@ std::multimap<std::string,ServiceInterface> getServices(const SharedFileHandle& 
 				log_error("Did not find any pods matching service selector for " << nspace << "::" << serviceName);
 				continue;
 			}
-			if(podData["items"][0]["status"].HasMember("hostIP"))
-				interface.externalIP=podData["items"][0]["status"]["hostIP"].GetString();
-			else
+			if(podData["items"][0]["status"].HasMember("hostIP")){
+				// now we should get the node info, to see if it has a ExternalIP which we ought to preferentially use
+				if(podData["items"][0]["spec"].HasMember("nodeName")) {
+					auto nodename=podData["Items"][0]["spec"]["nodeName"].GetString();
+
+					t1 = high_resolution_clock::now();
+					auto nodeResult=kubernetes::kubectl(*configPath,{"get","node",nodename,"-o=json"});
+					t2 = high_resolution_clock::now();
+					log_info("kubectl get node completed in " << duration_cast<duration<double>>(t2-t1).count() << " seconds");
+					if(nodeResult.status){
+						log_error("kubectl get node " << nodename << << " failed: " << nodeResult.error);
+						continue;
+					}
+
+					// preemptively set the externalIP to hostIP from the pod
+					// data, but we'll try to get something more accurate
+					interface.externalIP=podData["items"][0]["status"]["hostIP"].GetString();
+
+					rapidjson::Document nodeData;
+					try{
+						nodeData.Parse(nodeResult.output.c_str());
+					}catch(std::runtime_error& err){
+						log_error("Unable to parse kubectl node JSON output for kubectl get node " << nodename << ": " << err.what());
+						continue;
+					}
+
+					if(nodeData.HasMember("status"){
+						for (auto& addr : nodeData["status"]["addresses"].GetArray()) {
+							std::string addrType(addr["type"].GetString());
+							// assume that externalIP won't show up more than once
+							if (addrType == "ExternalIP") {
+								interface.externalIP=addr["address"].GetString();
+							}
+						}
+					} 
+				} 
+			} else {
 				interface.externalIP="<none>";
+            }
 		}
 		else if(serviceType=="ClusterIP"){
 			//Do nothing


### PR DESCRIPTION
This patch attempts to fix issue #95. 

If a pod has an IP, we look to see which node it is running on, and then attempt to ask Kubernetes for the node information and extract the address of type ExternalIP, and assign that to `interface.externalIP`. Failing that, we back out and set the externalIP to whatever is reported by the pod for the hostIP value. 