### PR TITLE
Report user error on failed install

### DIFF
--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -235,12 +235,12 @@ crow::response installApplicationImpl(PersistentStore& store, const User& user, 
 	
 	std::string yamlError;
 	//returns true if YAML parsing was successful
-	auto extractInstanceTag=[&tag,&gotTag](const std::string& config, std::string* error)->bool{
+	auto extractInstanceTag=[&tag,&gotTag](const std::string& config, std::string& error)->bool{
 		std::vector<YAML::Node> parsedConfig;
 		try{
 			parsedConfig=YAML::LoadAll(config);
 		}catch(const YAML::ParserException& ex){
-			*error = ex.what();
+			error = ex.what();
 			return false;
 		}
 		for(const auto& document : parsedConfig){


### PR DESCRIPTION
A simple change that now shows parse errors on a failed install to the user

close #104 