### PR TITLE
Add --conf flag to instance info command

### DIFF
--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -178,6 +178,7 @@ struct InstanceListOptions{
 
 struct InstanceOptions{
 	std::string instanceID;
+	bool confOnly;
 };
 
 struct InstanceDeleteOptions : public InstanceOptions{

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -2106,9 +2106,9 @@ void Client::getInstanceInfo(const InstanceOptions& opt){
 					}
 				}
 			}
+			std::cout << '\n' << bold("Configuration:"); // This line is only useful if slate instance info is being used in the default sense.
 		}
 		// Configuration is/should be provided regardless of confOnly
-		std::cout << '\n' << bold("Configuration:");
 		if(body["metadata"]["configuration"].IsNull()
 		   || (body["metadata"]["configuration"].IsString() && 
 		       std::string(body["metadata"]["configuration"].GetString())

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1898,9 +1898,9 @@ void Client::getInstanceInfo(const InstanceOptions& opt){
 	auto response=httpRequests::httpGet(url,defaultOptions());
 	//TODO: handle errors, make output nice
 	if(response.status==200){
+		rapidjson::Document body;
+		body.Parse(response.body.c_str());
 		if (!opt.confOnly) {
-			rapidjson::Document body;
-			body.Parse(response.body.c_str());
 			std::cout << formatOutput(body, body,
 									  {{"Name", "/metadata/name"},
 									   {"Started", "/metadata/created", true},

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -357,6 +357,7 @@ void registerInstanceInfo(CLI::App& parent, Client& client){
 	auto instOpt = std::make_shared<InstanceOptions>();
     auto info = parent.add_subcommand("info", "Fetch information about a deployed instance");
 	info->add_option("instance", instOpt->instanceID, "The ID of the instance")->required();
+	info->add_flag("--conf", instOpt->confOnly, "Fetch only instance configuration info");
     info->callback([&client,instOpt](){ client.getInstanceInfo(*instOpt); });
 }
 


### PR DESCRIPTION
This PR introduces changes that allow the user to exclusively request the configuration of an instance. Currently, it works by adding a boolean member to the InstanceOptions struct, and if set to true, will skip the steps that output anything other than the configuration. It does not change the actual query made by the client, and it does not add any new behavior to the server, but that remains a viable course of action if these changes are deemed insufficient.