### PR TITLE
Address fundamental issues with volume deletion caused by the inability of Kubernetes to reliably delete PVCs currently mounted by one or more pod(s)

### DIFF
--- a/resources/api_specification/VolumeInfoResultSchema.json
+++ b/resources/api_specification/VolumeInfoResultSchema.json
@@ -49,6 +49,9 @@
         "selectorLabelExpressions": {
           "type": "array",
           "items": {"type": "string"}
+        },
+        "status" : {
+          "type": "string"
         }
       },
       "required": ["id","name","group","cluster","created", "storageRequest", "accessMode", "volumeMode", "storageClass"]

--- a/resources/api_specification/VolumeListResultSchema.json
+++ b/resources/api_specification/VolumeListResultSchema.json
@@ -48,6 +48,9 @@
               "volumeMode": {
                 "type": "string",
                 "enum": ["Filesystem", "Block"]
+              },
+              "status" : {
+                "type": "string"
               }
             },
             "required": ["name","id","cluster","group","created", "storageClass"]

--- a/src/VolumeClaimCommands.cpp
+++ b/src/VolumeClaimCommands.cpp
@@ -78,12 +78,6 @@ crow::response listVolumeClaims(PersistentStore& store, const crow::request& req
 			log_error("kubectl get PVC " << volume.name << " --namespace " 
 				   << nspace << "failed :" << volumeResult.error);
 		}
-		try{
-			volumeData.Parse(volumeResult.output.c_str());
-		}
-		catch {
-			log_error("Unable to parse kubectl get PVC JSON output for " << volume.name << ": " << err.what());
-		}
 
 		// Add volume status from K8s (Bound, Pending...)
 		volumeData.AddMember("status", volumeData["status"]["phase"].GetString(), alloc);

--- a/src/VolumeClaimCommands.cpp
+++ b/src/VolumeClaimCommands.cpp
@@ -508,13 +508,13 @@ namespace internal{
 				const std::string nspace = group.namespaceName();
 
 				// Find out if PVC is mounted by any pods
-				std::vector<std::string> podsMountedBy = new std::vector<std::string>();
+				std::vector<std::string> podsMountedBy = {};
 
 				// Get all pods in the same namespace (This is the set of pods that are "eligible" to mount this volume)
 				auto podResult=kubernetes::kubectl(*configPath, {"get", "pods", "--namespace", nspace});
 				if (podResult.status)
 				{
-					log_error("kubectl get pods failed: " << deletionResult.error);
+					log_error("kubectl get pods failed: " << podResult.error);
 				}
 
 				rapidjson::Document podData;
@@ -524,7 +524,7 @@ namespace internal{
 				for(const auto& pod : podData["items"].GetArray()){
 					// For volumes of "type" PersistentVolumeClaims check PersistentVolumeClaim.ClaimName
 					// If ClaimName matches volume.name push PodName onto the list of podsMountedBy
-					for (const auto& podVolume : pod["volumes"].GetArrray()){
+					for (const auto& podVolume : pod["volumes"].GetArray()){
 						if(podVolume.HasMember("persistentVolumeClaim") && podVolume["persistentVolumeClaim"]["claimName"] == volume.name)
 							podsMountedBy.push_back(pod["metadata"]["generateName"].GetString());
 					}

--- a/src/VolumeClaimCommands.cpp
+++ b/src/VolumeClaimCommands.cpp
@@ -79,8 +79,16 @@ crow::response listVolumeClaims(PersistentStore& store, const crow::request& req
 				   << nspace << "failed :" << volumeResult.error);
 		}
 
+		rapidjson::GenericValue volumeStatus;
+
+		try {
+			volumeStatus.Parse(volume.result)
+		}catch(std::runtime_error& err){
+			log_error("Unable to parse kubectl get PVC JSON output for " << volume.name << ": " << err.what());
+		}
+
 		// Add volume status from K8s (Bound, Pending...)
-		volumeData.AddMember("status", volumeData["status"]["phase"].GetString(), alloc);
+		volumeData.AddMember("status", volumeStatus["status"]["phase"].GetString(), alloc);
 		volumeResult.AddMember("metadata", volumeData, alloc);
 		resultItems.PushBack(volumeResult, alloc);
 	}

--- a/src/VolumeClaimCommands.cpp
+++ b/src/VolumeClaimCommands.cpp
@@ -508,7 +508,7 @@ namespace internal{
 				const std::string nspace = group.namespaceName();
 
 				// Find out if PVC is mounted by any pods
-				std::vector<std::string> podsMountedBy;
+				std::vector<std::string> podsMountedBy = new std::vector<std::string>();
 
 				// Get all pods in the same namespace (This is the set of pods that are "eligible" to mount this volume)
 				auto podResult=kubernetes::kubectl(*configPath, {"get", "pods", "--namespace", nspace});
@@ -517,17 +517,27 @@ namespace internal{
 					log_error("kubectl get pods failed: " << deletionResult.error);
 				}
 
-				// For each pod in the namespace loop through each of the pod's volumes (pod.Spec.Volumes)
-				// podResult.output.c_str ...
+				rapidjson::Document podData;
 
-				// For volumes of "type" PersistentVolumeClaims check PersistentVolumeClaim.ClaimName
-				// If ClaimName matches volume.name push PodName onto the list of podsMountedBy
+				// For each pod in the namespace loop through each of the pod's volumes (pod.Spec.Volumes)
+				podData.Parse(podResult.output.c_str());
+				for(const auto& pod : podData["items"].GetArray()){
+					// For volumes of "type" PersistentVolumeClaims check PersistentVolumeClaim.ClaimName
+					// If ClaimName matches volume.name push PodName onto the list of podsMountedBy
+					for (const auto& podVolume : pod["volumes"].GetArrray()){
+						if(podVolume.HasMember("persistentVolumeClaim") && podVolume["persistentVolumeClaim"]["claimName"] == volume.name)
+							podsMountedBy.push_back(pod["metadata"]["generateName"].GetString());
+					}
+				}				
 
 				// If after checking all pods in the namespace the list of podsMountedBy is nonempty
 				// Warn the user and abort the operation.
-				if(podsMountedBy)
+				if(!podsMountedBy.empty())
 				{
-					return "Cannot delete volume from Kubernetes which is currently mounted by one or more pods: " << podsMountedBy;
+					std::string err = "Cannot delete volume from Kubernetes which is currently mounted by one or more pods: ";
+					for(const std::string podName : podsMountedBy)
+						err+=podName;
+					return err;
 				}
 
 				auto deletionResult=kubernetes::kubectl(*configPath, 


### PR DESCRIPTION
Closes #116 

Several enhancements to the information SLATE provides on Volumes from Kubernetes:

-`slate volume list` now displays the phase/status of each Volume in an additional column (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#persistentvolumeclaimstatus-v1-core)

-`slate volume delete` will now check *every* Pod within the relevant Kubernetes namespace and inspect each of the Pod's Volumes. If any are found which match the SLATE Volume given in delete, then the volume is mounted by a pod and cannot be deleted. A warning that specifies the list of conflicting pods is printed and the operation is aborted.

**TODO**

-Should probably remove the --force flag? Since force deletion of PVC appears to be problematic in Kubernetes

-Expand `slate volume info` to report status and mount information. 

**Concerns**

_Currently the best information we can report to the user about the pod(s) mounting the volume being deleted is the Pod Name. The Pod Name does contain the instance tag if there was one, and the corresponding instance should be searchable. It is workable but not great user experience. A better solution would be to have SLATE be able to report the instance ID a pod came from. This would require the pod to know its instance ID. A label could be used for this._