### PR TITLE
include CNCF inclusive phrasing in cluster registration

### DIFF
--- a/src/client/ClusterRegistration.cpp
+++ b/src/client/ClusterRegistration.cpp
@@ -467,7 +467,7 @@ metadata:
 	std::string badnessReason;
 	{
 		std::string cleanOutput=removeShellEscapeSequences(result.output);
-		static std::string label="Kubernetes master is running at ";
+		std::string label="Kubernetes master is running at ";
 		auto pos=cleanOutput.find(label);
 		if(pos==std::string::npos) {
 			label="Kubernetes control plane is running at "; // look for cncf phrasing

--- a/src/client/ClusterRegistration.cpp
+++ b/src/client/ClusterRegistration.cpp
@@ -467,8 +467,12 @@ metadata:
 	std::string badnessReason;
 	{
 		std::string cleanOutput=removeShellEscapeSequences(result.output);
-		static const std::string label="Kubernetes master is running at ";
+		static std::string label="Kubernetes master is running at ";
 		auto pos=cleanOutput.find(label);
+		if(pos==std::string::npos) {
+			label="Kubernetes control plane is running at "; // look for cncf phrasing
+			pos=cleanOutput.find(label);
+		}
 		if(pos==std::string::npos)
 			badnessReason="Unable to find expected label in kubectl output";
 		else{


### PR DESCRIPTION
Closes #120 

A simple change in logic that also searches for CNCF "Kubernetes control plane is running at " verbiage. It makes the `label` variable no longer const (as it needs to be either "Kubernetes control plane is running at " or "Kubernetes master is running at " respectively). Please let me know if that should cause problems later on down the line, I personally found no evidence that it would, as it seems to build and run just fine but there's no harm in testing it yourself!