### PR TITLE
Add instaceID to instance chart

### DIFF
--- a/include/ApplicationCommands.h
+++ b/include/ApplicationCommands.h
@@ -25,7 +25,7 @@ namespace internal{
 	///Construct the additional set of values which should be injected into the helm template
 	///when installing an application. 
 	///\param cluster the cluster on which the application is to be installed
-	std::string assembleExtraHelmValues(const PersistentStore& store, const Cluster& cluster);
+	std::string assembleExtraHelmValues(const PersistentStore& store, const Cluster& cluster, const ApplicationInstance& instance);
 }
 
 #endif //SLATE_APPLICATION_COMMANDS_H

--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -196,7 +196,7 @@ crow::response fetchApplicationDocumentation(PersistentStore& store, const crow:
 
 namespace internal{
 
-std::string assembleExtraHelmValues(const PersistentStore& store, const Cluster& cluster){
+std::string assembleExtraHelmValues(const PersistentStore& store, const Cluster& cluster, const ApplicationInstance& instance){
 	std::string additionalValues;
 	if(!store.getAppLoggingServerName().empty()){
 		additionalValues+="SLATE.Logging.Enabled=true";
@@ -207,6 +207,7 @@ std::string assembleExtraHelmValues(const PersistentStore& store, const Cluster&
 		additionalValues+="SLATE.Logging.Enabled=false";
 	additionalValues+=",SLATE.Cluster.Name="+cluster.name;
 	additionalValues+=",SLATE.Cluster.DNSName="+store.dnsNameForCluster(cluster);
+	additionalValues+=",metadata.instanceID="+instance.id;
 	
 	return additionalValues;
 }
@@ -350,8 +351,7 @@ crow::response installApplicationImpl(PersistentStore& store, const User& user, 
 		                                        " record to the persistent store"));
 	}
 	
-	std::string additionalValues=internal::assembleExtraHelmValues(store,cluster);
-	
+	std::string additionalValues=internal::assembleExtraHelmValues(store,cluster,instance);
 	log_info("Additional values: " << additionalValues);
 
 	auto clusterConfig=store.configPathForCluster(cluster.id);

--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -207,7 +207,7 @@ std::string assembleExtraHelmValues(const PersistentStore& store, const Cluster&
 		additionalValues+="SLATE.Logging.Enabled=false";
 	additionalValues+=",SLATE.Cluster.Name="+cluster.name;
 	additionalValues+=",SLATE.Cluster.DNSName="+store.dnsNameForCluster(cluster);
-	additionalValues+=",metadata.instanceID="+instance.id;
+	additionalValues+=",SLATE.Instance.ID="+instance.id;
 	
 	return additionalValues;
 }

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -357,7 +357,7 @@ rapidjson::Value fetchInstanceDetails(PersistentStore& store,
 				rapidjson::Value containers(rapidjson::kArrayType);
 				for(auto& item : pod["status"]["containerStatuses"].GetArray()){
 					rapidjson::Value container(rapidjson::kObjectType);
-					//TODO: when dealing with an image from a non-default
+					//TODO: when deealing with an image from a non-default
 					//registry, we shold make sure to capture that somewhere
 					if(item.HasMember("image"))
 						container.AddMember("image",item["image"],alloc);
@@ -710,7 +710,7 @@ crow::response restartApplicationInstance(PersistentStore& store, const crow::re
 			return crow::response(500,generateError("Failed to write instance configuration to disk"));
 		}
 	}
-	std::string additionalValues=internal::assembleExtraHelmValues(store,cluster);
+	std::string additionalValues=internal::assembleExtraHelmValues(store,cluster,instance);
 	
 	try{
 		kubernetes::kubectl_create_namespace(*clusterConfig, group);

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -357,7 +357,7 @@ rapidjson::Value fetchInstanceDetails(PersistentStore& store,
 				rapidjson::Value containers(rapidjson::kArrayType);
 				for(auto& item : pod["status"]["containerStatuses"].GetArray()){
 					rapidjson::Value container(rapidjson::kObjectType);
-					//TODO: when deealing with an image from a non-default
+					//TODO: when dealing with an image from a non-default
 					//registry, we shold make sure to capture that somewhere
 					if(item.HasMember("image"))
 						container.AddMember("image",item["image"],alloc);

--- a/src/VolumeClaimCommands.cpp
+++ b/src/VolumeClaimCommands.cpp
@@ -508,7 +508,7 @@ namespace internal{
 				const std::string nspace = group.namespaceName();
 
 				// Find out if PVC is mounted by any pods
-				std::vector<std::string> podsMountedBy = {};
+				std::vector<std::vector<std::string>> podsMountedBy;
 
 				// Get all pods in the same namespace (This is the set of pods that are "eligible" to mount this volume)
 				auto podResult=kubernetes::kubectl(*configPath, {"get", "pods", "--namespace", nspace, "-o=json"});
@@ -537,7 +537,14 @@ namespace internal{
 					// If ClaimName matches volume.name push PodName onto the list of podsMountedBy
 					for (const auto& podVolume : pod["spec"]["volumes"].GetArray()){
 						if(podVolume.HasMember("persistentVolumeClaim") && podVolume["persistentVolumeClaim"]["claimName"] == volume.name)
-							podsMountedBy.push_back(pod["metadata"]["generateName"].GetString());
+						{
+							std::vector<std::string> podInfo = {};
+							podInfo.push_back(pod["metadata"]["generateName"].GetString());
+							if (pod["metadata"].HasMember("instanceID")) { // add the instance ID if it is present
+								podInfo.push_back(pod["metadata"]["instanceID"].GetString());
+							}
+							podsMountedBy.push_back(podInfo);
+						}
 					}
 				}				
 
@@ -546,9 +553,13 @@ namespace internal{
 				if(!podsMountedBy.empty())
 				{
 					std::string err = "Cannot delete volume from Kubernetes which is currently mounted by one or more pods: ";
-					for(const std::string podName : podsMountedBy)
-						err+=podName;
-
+					for(const auto& pod : podsMountedBy) {
+						err+=pod.at(0);
+						if (pod.size() > 1) {
+							err += " (Slate ID: " + pod.at(1) + ") ";
+						}
+					}
+						
 					log_info("Cannot delete volume from Kubernetes which is currently mounted by one or more pods.");
 					return err;
 				}

--- a/src/VolumeClaimCommands.cpp
+++ b/src/VolumeClaimCommands.cpp
@@ -540,8 +540,8 @@ namespace internal{
 						{
 							std::vector<std::string> podInfo = {};
 							podInfo.push_back(pod["metadata"]["generateName"].GetString());
-							if (pod["SLATE"].HasMember("Instance") && pod["SLATE"]["Instance"].HasMember("ID")) { // add the instance ID if it is present
-								podInfo.push_back(pod["SLATE"]["Instance"]["ID"].GetString());
+							if (pod.HasMember("metadata") && pod["metadata"].HasMember("labels") && pod["metadata"]["labels"].HasMember("instanceID")) { // add the instance ID if it is present
+								podInfo.push_back(pod["metadata"]["labels"]["instanceID"].GetString());
 							}
 							podsMountedBy.push_back(podInfo);
 						}


### PR DESCRIPTION
Adds an `instanceID` field to `metadata` when installing an application, and also updates `VolumeClaimCommands.cpp` to include the ID (if applicable) when a deletion fails due to mounted instances