### PR TITLE
Fix exception when trying to get instance info for failed pods

### DIFF
--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -352,7 +352,7 @@ rapidjson::Value fetchInstanceDetails(PersistentStore& store,
 			if(pod["status"].HasMember("conditions"))
 				podInfo.AddMember("conditions",pod["status"]["conditions"],alloc);
 			if(pod["status"].HasMember("message"))
-				podInfo.AddMember("message",pod["status"]["conditions"],alloc);
+				podInfo.AddMember("message",pod["status"]["message"],alloc);
 			if(pod["status"].HasMember("containerStatuses")){
 				rapidjson::Value containers(rapidjson::kArrayType);
 				for(auto& item : pod["status"]["containerStatuses"].GetArray()){


### PR DESCRIPTION
Suggested by @cnweaver to fix the following bug:
```
Assertion failed: IsString() (/home/builder/slate-client-server/include/rapidjson/document.h: GetString: 1769)
```