### PR TITLE
Allow the chart version to be specified when interacting with SLATE applications

### DIFF
--- a/include/ApplicationCommands.h
+++ b/include/ApplicationCommands.h
@@ -18,7 +18,7 @@ crow::response fetchApplicationDocumentation(PersistentStore& store, const crow:
 crow::response installApplication(PersistentStore& store, const crow::request& req, const std::string& appName);
 ///List all the chart versions available for an application
 ///\param appName the application to search for
-crow::response fetchApplicationVesions(PersistentStore& store, const crow::request& req, const std::string& appName);
+crow::response fetchApplicationVersions(PersistentStore& store, const crow::request& req, const std::string& appName);
 ///Install an instance of an application from outside the catalog
 crow::response installAdHocApplication(PersistentStore& store, const crow::request& req);
 ///Update the application catalog

--- a/include/ApplicationCommands.h
+++ b/include/ApplicationCommands.h
@@ -16,6 +16,9 @@ crow::response fetchApplicationDocumentation(PersistentStore& store, const crow:
 ///Install an instance of an application
 ///\param appName the application to install
 crow::response installApplication(PersistentStore& store, const crow::request& req, const std::string& appName);
+///List all the chart versions available for an application
+///\param appName the application to search for
+crow::response fetchApplicationVesions(PersistentStore& store, const crow::request& req, const std::string& appName);
 ///Install an instance of an application from outside the catalog
 crow::response installAdHocApplication(PersistentStore& store, const crow::request& req);
 ///Update the application catalog

--- a/include/PersistentStore.h
+++ b/include/PersistentStore.h
@@ -572,10 +572,11 @@ public:
 
 	///Look up one application, returning a cached result if possible.
 	///\param repository the name of the repository in which to search
-	///\prama appName the name of the application to look uo
+	///\param appName the name of the application to look up
+	///\param chartVersion the chartVersion of the application to look up
 	///\return the application details, which may not be valid if the application was not found
 	///\throws std::runtime_error if the helm search command fails	
-	Application findApplication(const std::string& repository, const std::string& appName);
+	Application findApplication(const std::string& repository, const std::string& appName, const std::string& chartVersion);
 
 	///Unconditionally look up the applications in the given repository, updating the cache while doing so. 
 	///\param repository the name of the repository in which to search

--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -162,9 +162,7 @@ struct ApplicationConfOptions : public ApplicationOptions{
 };
 
 struct ApplicationInstallOptions : public ApplicationOptions{
-	ApplicationInstallOptions():fromLocalChart(false){}
-	// default latest chart
-	ApplicationConfOptions():chartVersion(""){}
+	ApplicationInstallOptions():fromLocalChart(false),chartVersion(""){}
 
 	std::string appName;
 	std::string cluster;

--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -163,11 +163,14 @@ struct ApplicationConfOptions : public ApplicationOptions{
 
 struct ApplicationInstallOptions : public ApplicationOptions{
 	ApplicationInstallOptions():fromLocalChart(false){}
+	// default latest chart
+	ApplicationConfOptions():chartVersion(""){}
 
 	std::string appName;
 	std::string cluster;
 	std::string group;
 	std::string configPath;
+	std::string chartVersion;
 	bool fromLocalChart;
 };
 

--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -158,7 +158,7 @@ struct ApplicationOptions{
 
 struct ApplicationConfOptions : public ApplicationOptions{
 	ApplicationConfOptions():chartVersion(""){}
-	
+
 	std::string chartVersion;
 	std::string appName;
 	std::string outputFile;
@@ -377,6 +377,8 @@ public:
 	void listApplications(const ApplicationOptions& opt);
 	
 	void getApplicationConf(const ApplicationConfOptions& opt);
+
+	void getApplicationVersions(const ApplicationConfOptions& opt);
 	
 	void getApplicationDocs(const ApplicationConfOptions& opt);
 	

--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -157,6 +157,9 @@ struct ApplicationOptions{
 };
 
 struct ApplicationConfOptions : public ApplicationOptions{
+	ApplicationConfOptions():chartVersion(""){}
+	
+	std::string chartVersion;
 	std::string appName;
 	std::string outputFile;
 };

--- a/resources/api_specification/AppInstallRequestSchema.json
+++ b/resources/api_specification/AppInstallRequestSchema.json
@@ -15,6 +15,9 @@
     },
     "configuration": {
       "type": "string"
+    },
+    "chartVersion": {
+      "type": "string"
     }
   },
   "required": ["apiVersions","group","cluster","configuration"]

--- a/resources/api_specification/AppVersionsResultSchema.json
+++ b/resources/api_specification/AppVersionsResultSchema.json
@@ -1,0 +1,35 @@
+{
+    "type": "object",
+    "$schema": "http://json-schema.org/draft-03/schema",
+    "id": "http://jsonschema.net",
+    "properties": {
+      "apiVersion": {
+        "type": "string",
+        "enum": [ "v1alpha3" ]
+      },
+      "kind": {
+        "type": "string",
+        "enum": [ "Configuration" ]
+      },
+      "metadata": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["name"]
+      },
+      "spec": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": ["body"]
+      }
+    },
+    "required": ["apiVersion","kind","metadata","spec"]
+  }
+  

--- a/resources/api_specification/slate.raml
+++ b/resources/api_specification/slate.raml
@@ -1202,6 +1202,30 @@ version: v1alpha3
             body:
               application/json:
                 type: !include ErrorResultSchema.json
+    /versions:
+      get:
+        description: Get an application's available chart versions
+        queryParameters:
+          token:
+            displayName: Access Token
+            type: string
+            description: User's authentication token
+            required: false
+          dev:
+            displayName: Development flag
+            type: boolean
+            description: Whether to search the development repository
+            required: false
+        responses:
+          200: # normal success
+            body:
+              application/json:
+                type: !include AppVersionsResultSchema.json
+          404: # if appName is not known
+            description: Application not found error
+            body:
+              application/json:
+                type: !include ErrorResultSchema.json
   /ad-hoc:
     post: # slate app install
       description: Install an application

--- a/resources/docs/client_manual.md
+++ b/resources/docs/client_manual.md
@@ -40,6 +40,7 @@ Table of Contents
       1. [app info](#app-info)
       1. [app get-conf](#app-get-conf)
       1. [app install](#app-install)
+      1. [app versions](#app-versions) 
    1. [Application Instance Commands](#application-instance-commands)
       1. [instance list](#instance-list)
       1. [instance info](#instance-info)
@@ -626,6 +627,25 @@ Example:
 In this case, the osg-frontier-squid application is installed with all configuration left set to defaults. The full instance name is the combination of the group name, the application name, and the user-supplied tag. 
 
 This command also has a second usage: To install a helm chart which is stored locally, rather than one published in the application catalog. This use is not permitted by default, but is enabled in testing environments like [miniSLATE](https://github.com/slateci/minislate) in order to allow application developers to test their charts. This special mode is triggered by using the `--local` option, which changes the interpretation of the specified application name from being a name to be looked up in the catalog to being a local filesystem path to the chart to be uploaded to the server and installed. 
+
+### app versions
+
+List all available versions of an application. 
+
+Example:
+
+	$ slate app versions nginx
+	1.2.0
+	1.10.11
+	1.10.10
+	1.10.9
+
+The application versions reported by SLATE correspond to the underlying Helm Chart version. By default, the latest version of an application will be installed. It is possible to specify an older version during app installation by using `--version`. 
+
+Example:
+
+	$ slate app install --group my-group --cluster my-cluster nginx --version 1.10.11
+	Successfully installed application nginx as instance my-group-nginx-test with ID instance_MzqXfaHkpQi
 
 Application Instance Commands
 -----------------------------

--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -152,7 +152,7 @@ crow::response fetchApplicationConfig(PersistentStore& store, const crow::reques
 	return crow::response(to_string(result));
 }
 
-crow::response fetchApplicationVesions(PersistentStore& store, const crow::request& req, const std::string& appName){
+crow::response fetchApplicationVersions(PersistentStore& store, const crow::request& req, const std::string& appName){
 	const User user=authenticateUser(store, req.url_params.get("token"));
 	if(!user) //non-users _are_ allowed to get documentation
 		log_info("Anonymous user requested to fetch documentation for application " << appName << " from " << req.remote_endpoint);

--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -191,6 +191,9 @@ crow::response fetchApplicationVersions(PersistentStore& store, const crow::requ
 		versions.append("\n");
 	} */
 
+	rapidjson::Document chartSearchDetails;
+	chartSearchDetails.Parse(commandResult.output.c_str());
+
 	rapidjson::Document result(rapidjson::kObjectType);
 	rapidjson::Document::AllocatorType& alloc = result.GetAllocator();
 	
@@ -202,7 +205,7 @@ crow::response fetchApplicationVersions(PersistentStore& store, const crow::requ
 	result.AddMember("metadata", metadata, alloc);
 
 	rapidjson::Value spec(rapidjson::kObjectType);
-	spec.AddMember("body", commandResult.output, alloc);
+	spec.AddMember("body", chartSearchDetails["version"].GetString(), alloc);
 	result.AddMember("spec", spec, alloc);
 
 	return crow::response(to_string(result));

--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -112,10 +112,14 @@ crow::response fetchApplicationConfig(PersistentStore& store, const crow::reques
 
 	auto repo=selectRepo(req);
 	std::string repoName=getRepoName(repo);
+
+	std::string chartVersion = "";
+	if (req.url_params.get("chartVersion"))
+		chartVersion = req.url_params.get("chartVersion");
 		
 	Application application;
 	try{
-		application=store.findApplication(repoName, appName, "");
+		application=store.findApplication(repoName, appName, chartVersion);
 	}
 	catch(std::runtime_error& err){
 		return crow::response(500);
@@ -123,7 +127,7 @@ crow::response fetchApplicationConfig(PersistentStore& store, const crow::reques
 	if(!application)
 		return crow::response(404,generateError("Application not found"));
 	
-	auto commandResult = runCommand("helm",{"inspect","values",repoName + "/" + appName});
+	auto commandResult = runCommand("helm",{"inspect","values",repoName + "/" + application.name, "--version", application.chartVersion});
 	if(commandResult.status){
 		log_error("Command failed: helm inspect " << (repoName + "/" + appName) << ": [exit] " << commandResult.status << " [err] " << commandResult.error << " [out] " << commandResult.output);
 		return crow::response(500, generateError("Unable to fetch application config"));
@@ -158,10 +162,14 @@ crow::response fetchApplicationDocumentation(PersistentStore& store, const crow:
 
 	auto repo=selectRepo(req);
 	std::string repoName=getRepoName(repo);
+
+	std::string chartVersion = "";
+	if (req.url_params.get("chartVersion"))
+		chartVersion = req.url_params.get("chartVersion");
 		
 	Application application;//=findApplication(appName,repo);
 	try{
-		application=store.findApplication(repoName, appName, "");
+		application=store.findApplication(repoName, appName, chartVersion);
 	}
 	catch(std::runtime_error& err){
 		return crow::response(500);
@@ -169,7 +177,7 @@ crow::response fetchApplicationDocumentation(PersistentStore& store, const crow:
 	if(!application)
 		return crow::response(404,generateError("Application not found"));
 	
-	auto commandResult = runCommand("helm",{"inspect","readme",repoName + "/" + appName});
+	auto commandResult = runCommand("helm",{"inspect","readme",repoName + "/" + application.name, "--version", application.chartVersion});
 	if(commandResult.status){
 		log_error("Command failed: helm inspect " << (repoName + "/" + appName) << ": [exit] " << commandResult.status << " [err] " << commandResult.error << " [out] " << commandResult.output);
 		return crow::response(500, generateError("Unable to fetch application readme"));

--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -283,7 +283,7 @@ crow::response installApplicationImpl(PersistentStore& store, const User& user, 
 		return crow::response(400,generateError("Incorrect type for configuration"));
 	const std::string config=body["configuration"].GetString();
 
-	const std::string chartVersion = "";
+	std::string chartVersion = "";
 	if(body["chartVersion"].IsString())
 		chartVersion = body["chartVersion"].GetString();
 

--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -283,6 +283,10 @@ crow::response installApplicationImpl(PersistentStore& store, const User& user, 
 		return crow::response(400,generateError("Incorrect type for configuration"));
 	const std::string config=body["configuration"].GetString();
 
+	const std::string chartVersion = "";
+	if(body["chartVersion"].IsString())
+		chartVersion = body["chartVersion"].GetString();
+
 	std::string tag; //start by assuming this is empty
 	bool gotTag=false;
 	
@@ -311,7 +315,7 @@ crow::response installApplicationImpl(PersistentStore& store, const User& user, 
 	//if the user did not specify a tag we must parse the base helm chart to 
 	//find out what the default value is
 	if(!gotTag){
-		auto commandResult = runCommand("helm",{"inspect","values",installSrc});
+		auto commandResult = runCommand("helm",{"inspect","values",installSrc, "--version", chartVersion});
 		if(commandResult.status){
 			log_error("Command failed: helm inspect values " << installSrc << ": [exit] " << commandResult.status << " [err] " << commandResult.error << " [out] " << commandResult.output);
 			return crow::response(500, generateError("Unable to fetch default application config"));
@@ -424,6 +428,7 @@ crow::response installApplicationImpl(PersistentStore& store, const User& user, 
 	   "--namespace",group.namespaceName(),
 	   "--values",instanceConfig.path(),
 	   "--set",additionalValues,
+	   "--version",chartVersion,
 	   };
 	unsigned int helmMajorVersion=kubernetes::getHelmMajorVersion();
 	if(helmMajorVersion==2){

--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -205,7 +205,7 @@ crow::response fetchApplicationVersions(PersistentStore& store, const crow::requ
 	result.AddMember("metadata", metadata, alloc);
 
 	rapidjson::Value spec(rapidjson::kObjectType);
-	spec.AddMember("body", chartSearchDetails["version"]., alloc);
+	spec.AddMember("body", chartSearchDetails["version"], alloc);
 	result.AddMember("spec", spec, alloc);
 
 	return crow::response(to_string(result));

--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -193,6 +193,12 @@ crow::response fetchApplicationVersions(PersistentStore& store, const crow::requ
 
 	rapidjson::Document chartSearchDetails;
 	chartSearchDetails.Parse(commandResult.output.c_str());
+	std::string versions = "";
+
+	for(const auto& chartEntry : chartSearchDetails.GetArray()){
+		versions.append(chartEntry["version"].ToString());
+		versions.append("\n");
+	}
 
 	rapidjson::Document result(rapidjson::kObjectType);
 	rapidjson::Document::AllocatorType& alloc = result.GetAllocator();
@@ -205,7 +211,7 @@ crow::response fetchApplicationVersions(PersistentStore& store, const crow::requ
 	result.AddMember("metadata", metadata, alloc);
 
 	rapidjson::Value spec(rapidjson::kObjectType);
-	spec.AddMember("body", chartSearchDetails["version"], alloc);
+	spec.AddMember("body", versions, alloc);
 	result.AddMember("spec", spec, alloc);
 
 	return crow::response(to_string(result));

--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -205,7 +205,7 @@ crow::response fetchApplicationVersions(PersistentStore& store, const crow::requ
 	result.AddMember("metadata", metadata, alloc);
 
 	rapidjson::Value spec(rapidjson::kObjectType);
-	spec.AddMember("body", chartSearchDetails["version"].GetString(), alloc);
+	spec.AddMember("body", chartSearchDetails["version"]., alloc);
 	result.AddMember("spec", spec, alloc);
 
 	return crow::response(to_string(result));

--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -196,7 +196,7 @@ crow::response fetchApplicationVersions(PersistentStore& store, const crow::requ
 	std::string versions = "";
 
 	for(const auto& chartEntry : chartSearchDetails.GetArray()){
-		versions.append(chartEntry["version"].ToString());
+		versions.append(chartEntry["version"].GetString());
 		versions.append("\n");
 	}
 

--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -115,7 +115,7 @@ crow::response fetchApplicationConfig(PersistentStore& store, const crow::reques
 		
 	Application application;
 	try{
-		application=store.findApplication(repoName, appName);
+		application=store.findApplication(repoName, appName, "");
 	}
 	catch(std::runtime_error& err){
 		return crow::response(500);
@@ -161,7 +161,7 @@ crow::response fetchApplicationDocumentation(PersistentStore& store, const crow:
 		
 	Application application;//=findApplication(appName,repo);
 	try{
-		application=store.findApplication(repoName, appName);
+		application=store.findApplication(repoName, appName, "");
 	}
 	catch(std::runtime_error& err){
 		return crow::response(500);
@@ -456,7 +456,7 @@ crow::response installApplication(PersistentStore& store, const crow::request& r
 	std::string repoName=getRepoName(repo);
 	Application application;
 	try{
-		application=store.findApplication(repoName, appName);
+		application=store.findApplication(repoName, appName, "");
 	}
 	catch(std::runtime_error& err){
 		return crow::response(500);

--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -185,7 +185,7 @@ crow::response fetchApplicationVersions(PersistentStore& store, const crow::requ
 	auto versions_begin = std::sregex_iterator(commandResult.output.begin(), commandResult.output.end(), match_version_strings);
 	auto versions_end = std::sregex_iterator();
 	std::string versions = "";
-	for (std::sregex_iterator version = versions_begin; version != versions_end; versions++){
+	for (std::sregex_iterator version = versions_begin; version != versions_end; version++){
 		versions.append((*version).str());
 		versions.append("\n");
 	}

--- a/src/PersistentStore.cpp
+++ b/src/PersistentStore.cpp
@@ -4045,7 +4045,7 @@ Application PersistentStore::findApplication(const std::string& repository, cons
 //		searchArgs.insert(searchArgs.begin()+2,"repo");
 	auto result=runCommand("helm", searchArgs);
 	if(result.status)
-		log_fatal("Command failed: helm search " << target << ": [err] " << result.error << " [out] " << result.output << searchArgs);
+		log_fatal("Command failed: helm search " << target << ": [err] " << result.error << " [out] " << result.output << searchArgs[0] << searchArgs[1] << searchArgs[2] << searchArgs[3] << searchArgs[4]);
 	log_info("Helm output: " << result.output);
 	if(result.output.find("No results found")!=std::string::npos)
 		return Application();

--- a/src/PersistentStore.cpp
+++ b/src/PersistentStore.cpp
@@ -4025,7 +4025,7 @@ std::vector<PersistentVolumeClaim> PersistentStore::listPersistentVolumeClaimsBy
 	return volumes;
 }
 
-Application PersistentStore::findApplication(const std::string& repository, const std::string& appName){
+Application PersistentStore::findApplication(const std::string& repository, const std::string& appName, const std::string& chartVersion){
 	{ //check for cached data first
 		log_info("Checking for application " << appName << " in cache");
 		auto cached = applicationCache.find(repository);
@@ -4040,7 +4040,7 @@ Application PersistentStore::findApplication(const std::string& repository, cons
 	//Need to query helm
 	log_info("Querying helm for application " << appName);
 	std::string target=repository+"/"+appName;
-	std::vector<std::string> searchArgs={"search",target};
+	std::vector<std::string> searchArgs={"search",target,"--version ",chartVersion};
 	if(kubernetes::getHelmMajorVersion()==3)
 		searchArgs.insert(searchArgs.begin()+1,"repo");
 	auto result=runCommand("helm", searchArgs);

--- a/src/PersistentStore.cpp
+++ b/src/PersistentStore.cpp
@@ -4040,9 +4040,9 @@ Application PersistentStore::findApplication(const std::string& repository, cons
 	//Need to query helm
 	log_info("Querying helm for application " << appName);
 	std::string target=repository+"/"+appName;
-	std::vector<std::string> searchArgs={"search","repo",target,"--version",chartVersion};
-//	if(kubernetes::getHelmMajorVersion()==3)
-//		searchArgs.insert(searchArgs.begin()+2,"repo");
+	std::vector<std::string> searchArgs={"search",target,"--version",chartVersion};
+	if(kubernetes::getHelmMajorVersion()==3)
+		searchArgs.insert(searchArgs.begin()+1,"repo");
 	auto result=runCommand("helm", searchArgs);
 	if(result.status)
 		log_fatal("Command failed: helm search " << target << ": [err] " << result.error << " [out] " << result.output);

--- a/src/PersistentStore.cpp
+++ b/src/PersistentStore.cpp
@@ -4040,12 +4040,12 @@ Application PersistentStore::findApplication(const std::string& repository, cons
 	//Need to query helm
 	log_info("Querying helm for application " << appName);
 	std::string target=repository+"/"+appName;
-	std::vector<std::string> searchArgs={"search","repo",target,"--version ",chartVersion};
+	std::vector<std::string> searchArgs={"search","repo",target,"--version",chartVersion};
 //	if(kubernetes::getHelmMajorVersion()==3)
 //		searchArgs.insert(searchArgs.begin()+2,"repo");
 	auto result=runCommand("helm", searchArgs);
 	if(result.status)
-		log_fatal("Command failed: helm search " << target << ": [err] " << result.error << " [out] " << result.output << searchArgs[0] << searchArgs[1] << searchArgs[2] << searchArgs[3] << searchArgs[4]);
+		log_fatal("Command failed: helm search " << target << ": [err] " << result.error << " [out] " << result.output);
 	log_info("Helm output: " << result.output);
 	if(result.output.find("No results found")!=std::string::npos)
 		return Application();

--- a/src/PersistentStore.cpp
+++ b/src/PersistentStore.cpp
@@ -4045,7 +4045,7 @@ Application PersistentStore::findApplication(const std::string& repository, cons
 //		searchArgs.insert(searchArgs.begin()+2,"repo");
 	auto result=runCommand("helm", searchArgs);
 	if(result.status)
-		log_fatal("Command failed: helm search " << target << ": [err] " << result.error << " [out] " << result.output);
+		log_fatal("Command failed: helm search " << target << ": [err] " << result.error << " [out] " << result.output << searchArgs);
 	log_info("Helm output: " << result.output);
 	if(result.output.find("No results found")!=std::string::npos)
 		return Application();

--- a/src/PersistentStore.cpp
+++ b/src/PersistentStore.cpp
@@ -4042,7 +4042,7 @@ Application PersistentStore::findApplication(const std::string& repository, cons
 	std::string target=repository+"/"+appName;
 	std::vector<std::string> searchArgs={"search",target,"--version ",chartVersion};
 	if(kubernetes::getHelmMajorVersion()==3)
-		searchArgs.insert(searchArgs.begin()+1,"repo");
+		searchArgs.insert(searchArgs.begin(),"repo");
 	auto result=runCommand("helm", searchArgs);
 	if(result.status)
 		log_fatal("Command failed: helm search " << target << ": [err] " << result.error << " [out] " << result.output);

--- a/src/PersistentStore.cpp
+++ b/src/PersistentStore.cpp
@@ -4040,9 +4040,9 @@ Application PersistentStore::findApplication(const std::string& repository, cons
 	//Need to query helm
 	log_info("Querying helm for application " << appName);
 	std::string target=repository+"/"+appName;
-	std::vector<std::string> searchArgs={"search",target,"--version ",chartVersion};
-	if(kubernetes::getHelmMajorVersion()==3)
-		searchArgs.insert(searchArgs.begin(),"repo");
+	std::vector<std::string> searchArgs={"repo","search",target,"--version ",chartVersion};
+//	if(kubernetes::getHelmMajorVersion()==3)
+//		searchArgs.insert(searchArgs.begin()+1,"repo");
 	auto result=runCommand("helm", searchArgs);
 	if(result.status)
 		log_fatal("Command failed: helm search " << target << ": [err] " << result.error << " [out] " << result.output);

--- a/src/PersistentStore.cpp
+++ b/src/PersistentStore.cpp
@@ -4040,9 +4040,9 @@ Application PersistentStore::findApplication(const std::string& repository, cons
 	//Need to query helm
 	log_info("Querying helm for application " << appName);
 	std::string target=repository+"/"+appName;
-	std::vector<std::string> searchArgs={"repo","search",target,"--version ",chartVersion};
-//	if(kubernetes::getHelmMajorVersion()==3)
-//		searchArgs.insert(searchArgs.begin()+1,"repo");
+	std::vector<std::string> searchArgs={"search",target,"--version ",chartVersion};
+	if(kubernetes::getHelmMajorVersion()==3)
+		searchArgs.insert(searchArgs.begin()+2,"repo");
 	auto result=runCommand("helm", searchArgs);
 	if(result.status)
 		log_fatal("Command failed: helm search " << target << ": [err] " << result.error << " [out] " << result.output);

--- a/src/PersistentStore.cpp
+++ b/src/PersistentStore.cpp
@@ -4040,9 +4040,9 @@ Application PersistentStore::findApplication(const std::string& repository, cons
 	//Need to query helm
 	log_info("Querying helm for application " << appName);
 	std::string target=repository+"/"+appName;
-	std::vector<std::string> searchArgs={"search",target,"--version ",chartVersion};
-	if(kubernetes::getHelmMajorVersion()==3)
-		searchArgs.insert(searchArgs.begin()+2,"repo");
+	std::vector<std::string> searchArgs={"search","repo",target,"--version ",chartVersion};
+//	if(kubernetes::getHelmMajorVersion()==3)
+//		searchArgs.insert(searchArgs.begin()+2,"repo");
 	auto result=runCommand("helm", searchArgs);
 	if(result.status)
 		log_fatal("Command failed: helm search " << target << ": [err] " << result.error << " [out] " << result.output);

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1704,8 +1704,7 @@ void Client::getApplicationConf(const ApplicationConfOptions& opt){
 		url+="&dev";
 	if(opt.testRepo)
 		url+="&test";
-	if(opt.chartVersion)
-		url+="&chartVersion="+opt.chartVersion;
+	url+="&chartVersion="+opt.chartVersion;
 
 	auto response=httpRequests::httpGet(url,defaultOptions());
 	//TODO: other output formats
@@ -1737,8 +1736,7 @@ void Client::getApplicationDocs(const ApplicationConfOptions& opt){
 		url+="&dev";
 	if(opt.testRepo)
 		url+="&test";
-	if(opt.chartVersion)
-		url+="&chartVersion="+opt.chartVersion;
+	url+="&chartVersion="+opt.chartVersion;
 
 	auto response=httpRequests::httpGet(url,defaultOptions());
 	//TODO: other output formats

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1728,6 +1728,37 @@ void Client::getApplicationConf(const ApplicationConfOptions& opt){
 		throw OperationFailed();
 	}
 }
+
+void Client::getApplicationVersions(const ApplicationConfOptions& opt){
+	ProgressToken progress(pman_,"Fetching application versions...");
+	std::string url=makeURL("apps/"+opt.appName+"/versions");
+	if(opt.devRepo)
+		url+="&dev";
+	if(opt.testRepo)
+		url+="&test";
+
+	auto response=httpRequests::httpGet(url,defaultOptions());
+	//TODO: other output formats
+	if(response.status==200){
+		rapidjson::Document resultJSON;
+		resultJSON.Parse(response.body.c_str());
+		std::string info=resultJSON["spec"]["body"].GetString();
+		//if the user specified a file, write there
+		if(!opt.outputFile.empty()){
+			std::ofstream confFile(opt.outputFile);
+			if(!confFile)
+				throw std::runtime_error("Unable to write chart versions to "+opt.outputFile);
+			confFile << info;
+		}
+		else //otherwise print to stdout
+			std::cout << info << std::endl;
+	}
+	else{
+		std::cerr << "Failed to get versions for application " << opt.appName;
+		showError(response.body);
+		throw OperationFailed();
+	}
+}
 	
 void Client::getApplicationDocs(const ApplicationConfOptions& opt){
 	ProgressToken progress(pman_,"Fetching application documentation...");

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1704,6 +1704,8 @@ void Client::getApplicationConf(const ApplicationConfOptions& opt){
 		url+="&dev";
 	if(opt.testRepo)
 		url+="&test";
+	if(opt.chartVersion)
+		url+="&chartVersion="+opt.chartVersion;
 
 	auto response=httpRequests::httpGet(url,defaultOptions());
 	//TODO: other output formats
@@ -1735,6 +1737,8 @@ void Client::getApplicationDocs(const ApplicationConfOptions& opt){
 		url+="&dev";
 	if(opt.testRepo)
 		url+="&test";
+	if(opt.chartVersion)
+		url+="&chartVersion="+opt.chartVersion;
 
 	auto response=httpRequests::httpGet(url,defaultOptions());
 	//TODO: other output formats

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1786,6 +1786,7 @@ void Client::installApplication(const ApplicationInstallOptions& opt){
 	request.AddMember("group", rapidjson::StringRef(opt.group.c_str()), alloc);
 	request.AddMember("cluster", rapidjson::StringRef(opt.cluster.c_str()), alloc);
 	request.AddMember("configuration", rapidjson::StringRef(configuration.c_str()), alloc);
+	request.AddMember("chartVersion", rapidjson::StringRef(opt.chartVersion.c_str()), alloc);
 	if(opt.fromLocalChart){
 		struct stat data;
 		int err=stat(opt.appName.c_str(),&data);

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -330,7 +330,7 @@ void registerApplicationInstall(CLI::App& parent, Client& client){
 	install->add_option("--group", appOpt->group, "Name of the group which will own the instance")->required();
 	install->add_option("--cluster", appOpt->cluster, "Name of the cluster on which the instance will run")->required();
 	install->add_option("--conf", appOpt->configPath, "File containing configuration for the instance");
-	isntall->add_option("--version", appOpt->chartVersion, "Version of the application chart to install");
+	install->add_option("--version", appOpt->chartVersion, "Version of the application chart to install");
 	install->add_flag("--dev", appOpt->devRepo, "Install from the development catalog");
 	install->add_flag("--test", appOpt->testRepo, "Install from the test catalog")->group("");
 	install->add_flag("--local", appOpt->fromLocalChart, "Install a local chart directly");

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -314,6 +314,16 @@ void registerApplicationGetConf(CLI::App& parent, Client& client){
     conf->callback([&client,appOpt](){ client.getApplicationConf(*appOpt); });
 }
 
+void registerApplicationVersions(CLI:App& parent, Client& client){
+	auto appOpt = std::make_share<ApplicationConfOptions>();
+	auto conf = parent.add_subcommand("versions", "Get the available chart versions for an application");
+	conf->add_option("app-name", appOpt->appName, "Name of the application to fetch")->required();
+	conf->add_option("-o,--output", appOpt->outputFile, "File to which to write the versions");
+	conf->add_flag("--dev", appOpt->devRepo, "Fetch from the development catalog");
+	conf->add_flag("--test", appOpt->testRepo, "Fetch from the test catalog")->group("");
+	conf->callback([&client,appOpt](){ client.getApplicationVersions(*appOpt); });
+}
+
 void registerApplicationGetDocs(CLI::App& parent, Client& client){
 	auto appOpt = std::make_shared<ApplicationConfOptions>();
     auto conf = parent.add_subcommand("info", "Get an application's documentation");
@@ -346,6 +356,7 @@ void registerApplicationCommands(CLI::App& parent, Client& client){
 	registerApplicationGetConf(*app, client);
 	registerApplicationGetDocs(*app, client);
 	registerApplicationInstall(*app, client);
+	registerApplicationVersions(*app, client);
 }
 
 void registerInstanceList(CLI::App& parent, Client& client){

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -330,6 +330,7 @@ void registerApplicationInstall(CLI::App& parent, Client& client){
 	install->add_option("--group", appOpt->group, "Name of the group which will own the instance")->required();
 	install->add_option("--cluster", appOpt->cluster, "Name of the cluster on which the instance will run")->required();
 	install->add_option("--conf", appOpt->configPath, "File containing configuration for the instance");
+	isntall->add_option("--version", appOpt->chartVersion, "Version of the application chart to install");
 	install->add_flag("--dev", appOpt->devRepo, "Install from the development catalog");
 	install->add_flag("--test", appOpt->testRepo, "Install from the test catalog")->group("");
 	install->add_flag("--local", appOpt->fromLocalChart, "Install a local chart directly");

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -310,6 +310,7 @@ void registerApplicationGetConf(CLI::App& parent, Client& client){
 	conf->add_option("-o,--output", appOpt->outputFile, "File to which to write the configuration");
 	conf->add_flag("--dev", appOpt->devRepo, "Fetch from the development catalog");
 	conf->add_flag("--test", appOpt->testRepo, "Fetch from the test catalog")->group("");
+	conf->add_flag("--version", appOpt->chartVersion, "Version of the application chart to fetch");
     conf->callback([&client,appOpt](){ client.getApplicationConf(*appOpt); });
 }
 
@@ -320,6 +321,7 @@ void registerApplicationGetDocs(CLI::App& parent, Client& client){
 	conf->add_option("-o,--output", appOpt->outputFile, "File to which to write the documentation");
 	conf->add_flag("--dev", appOpt->devRepo, "Fetch from the development catalog");
 	conf->add_flag("--test", appOpt->testRepo, "Fetch from the test catalog")->group("");
+	conf->add_flag("--version", appOpt->chartVersion, "Version of the application chart to fetch");
     conf->callback([&client,appOpt](){ client.getApplicationDocs(*appOpt); });
 }
 

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -310,7 +310,7 @@ void registerApplicationGetConf(CLI::App& parent, Client& client){
 	conf->add_option("-o,--output", appOpt->outputFile, "File to which to write the configuration");
 	conf->add_flag("--dev", appOpt->devRepo, "Fetch from the development catalog");
 	conf->add_flag("--test", appOpt->testRepo, "Fetch from the test catalog")->group("");
-	conf->add_flag("--version", appOpt->chartVersion, "Version of the application chart to fetch");
+	conf->add_option("--version", appOpt->chartVersion, "Version of the application chart to fetch");
     conf->callback([&client,appOpt](){ client.getApplicationConf(*appOpt); });
 }
 
@@ -321,7 +321,7 @@ void registerApplicationGetDocs(CLI::App& parent, Client& client){
 	conf->add_option("-o,--output", appOpt->outputFile, "File to which to write the documentation");
 	conf->add_flag("--dev", appOpt->devRepo, "Fetch from the development catalog");
 	conf->add_flag("--test", appOpt->testRepo, "Fetch from the test catalog")->group("");
-	conf->add_flag("--version", appOpt->chartVersion, "Version of the application chart to fetch");
+	conf->add_option("--version", appOpt->chartVersion, "Version of the application chart to fetch");
     conf->callback([&client,appOpt](){ client.getApplicationDocs(*appOpt); });
 }
 

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -315,7 +315,7 @@ void registerApplicationGetConf(CLI::App& parent, Client& client){
 }
 
 void registerApplicationVersions(CLI::App& parent, Client& client){
-	auto appOpt = std::make_share<ApplicationConfOptions>();
+	auto appOpt = std::make_shared<ApplicationConfOptions>();
 	auto conf = parent.add_subcommand("versions", "Get the available chart versions for an application");
 	conf->add_option("app-name", appOpt->appName, "Name of the application to fetch")->required();
 	conf->add_option("-o,--output", appOpt->outputFile, "File to which to write the versions");

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -314,7 +314,7 @@ void registerApplicationGetConf(CLI::App& parent, Client& client){
     conf->callback([&client,appOpt](){ client.getApplicationConf(*appOpt); });
 }
 
-void registerApplicationVersions(CLI:App& parent, Client& client){
+void registerApplicationVersions(CLI::App& parent, Client& client){
 	auto appOpt = std::make_share<ApplicationConfOptions>();
 	auto conf = parent.add_subcommand("versions", "Get the available chart versions for an application");
 	conf->add_option("app-name", appOpt->appName, "Name of the application to fetch")->required();

--- a/src/slate_service.cpp
+++ b/src/slate_service.cpp
@@ -563,6 +563,8 @@ int main(int argc, char* argv[]){
 	  [&](const crow::request& req, const std::string& aID){ return fetchApplicationConfig(store,req,aID); });
 	CROW_ROUTE(server, "/v1alpha3/apps/<string>/info").methods("GET"_method)(
 	  [&](const crow::request& req, const std::string& aID){ return fetchApplicationDocumentation(store,req,aID); });
+	CROW_ROUTE(server, "/v1alpha3/apps/<string>/versions").methods("GET"_method)(
+	  [&](const crow::request& req, const std::string& aID){ return fetchApplicationVersions(store,req,aID); });
 	if(config.allowAdHocApps){
 		CROW_ROUTE(server, "/v1alpha3/apps/ad-hoc").methods("POST"_method)(
 		  [&](const crow::request& req){ return installAdHocApplication(store,req); });


### PR DESCRIPTION
Adds a `--version` flag to key `slate app ...` commands allowing users to:

-Install a specific older version of a chart

-Retrieve values for any older chart version SLATE has built

-Retrieve documentation for old chart versions

It also seems important to add a way to access available versions for an application. A new command is introduce for doing this:

`slate app versions <app-name>`

Lists every available version for a specific SLATE application.

Emphasis has been placed on backwards compatibility. The new flag is purely *optional* and the latest version of the chart will always be retrieved by default. The updated server code is equipped to handle requests from old clients, which will also just result in the latest chart.