### PR TITLE
Add slate instance update commands

### DIFF
--- a/include/ApplicationInstanceCommands.h
+++ b/include/ApplicationInstanceCommands.h
@@ -13,6 +13,9 @@ crow::response fetchApplicationInstanceInfo(PersistentStore& store, const crow::
 ///Stop and restart an instance of an application
 ///\param instanceID the instance to restart
 crow::response restartApplicationInstance(PersistentStore& store, const crow::request& req, const std::string& instanceID);
+///Stop and restart an instance of an application applying an updated configuration file
+///\param instanceID the instance to restart
+crow::response updateApplicationInstance(PersistentStore& store, const crow::request& req, const std::string& instanceID);
 ///Destroy an instance of an application
 ///\param instanceID the instance to delete
 crow::response deleteApplicationInstance(PersistentStore& store, const crow::request& req, const std::string& instanceID);

--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -185,7 +185,7 @@ struct InstanceUpdateOptions{
 
 	std::string configPath;
 	std::string chartVersion;
-}
+};
 
 struct InstanceOptions{
 	std::string chartVersion;
@@ -397,6 +397,8 @@ public:
 	void getInstanceInfo(const InstanceOptions& opt);
 	
 	void restartInstance(const InstanceOptions& opt);
+
+	void updateInstance(const InstanceUpdateOptions& opt);
 	
 	void deleteInstance(const InstanceDeleteOptions& opt);
 	

--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -180,7 +180,7 @@ struct InstanceListOptions{
 	std::string cluster;
 };
 
-struct InstanceUpdateOptions{
+struct InstanceUpdateOptions : public InstanceOptions{
 	InstanceUpdateOptions():chartVersion(""){}
 
 	std::string configPath;

--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -180,7 +180,15 @@ struct InstanceListOptions{
 	std::string cluster;
 };
 
+struct InstanceUpdateOptions{
+	InstanceUpdateOptions():chartVersion(""){}
+
+	std::string configPath;
+	std::string chartVersion;
+}
+
 struct InstanceOptions{
+	std::string chartVersion;
 	std::string instanceID;
 	bool confOnly;
 };

--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -180,17 +180,19 @@ struct InstanceListOptions{
 	std::string cluster;
 };
 
-struct InstanceUpdateOptions : public InstanceOptions{
-	InstanceUpdateOptions():chartVersion(""){}
 
-	std::string configPath;
-	std::string chartVersion;
-};
 
 struct InstanceOptions{
 	std::string chartVersion;
 	std::string instanceID;
 	bool confOnly;
+};
+
+struct InstanceUpdateOptions : public InstanceOptions{
+	InstanceUpdateOptions():chartVersion(""){}
+
+	std::string configPath;
+	std::string chartVersion;
 };
 
 struct InstanceDeleteOptions : public InstanceOptions{

--- a/resources/api_specification/InstanceUpdateRequestSchema.json
+++ b/resources/api_specification/InstanceUpdateRequestSchema.json
@@ -1,0 +1,19 @@
+{
+    "type": "object",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "id": "http://jsonschema.net",
+    "properties": {
+      "apiVersion": {
+        "type": "string",
+        "enum": [ "v1alpha3" ]
+      },
+      "configuration": {
+        "type": "string"
+      },
+      "chartVersion": {
+        "type": "string"
+      }
+    },
+    "required": ["apiVersions","group","cluster","configuration"]
+  }
+  

--- a/resources/api_specification/slate.raml
+++ b/resources/api_specification/slate.raml
@@ -1113,6 +1113,11 @@ version: v1alpha3
           type: boolean
           description: Whether to search the developer repository
           required: false
+        version:
+            displayName: version
+            type: string
+            description: Which chart version to fetch
+            required: false
       responses:
         200: # normal success
           body:
@@ -1140,6 +1145,11 @@ version: v1alpha3
           displayName: Development flag
           description: Whether to search the development repository
           required: false
+        version:
+            displayName: version
+            type: string
+            description: Which chart version to fetch
+            required: false
       body:
         application/json:
           type: !include AppInstallRequestSchema.json
@@ -1191,6 +1201,11 @@ version: v1alpha3
             displayName: Development flag
             type: boolean
             description: Whether to search the development repository
+            required: false
+          version:
+            displayName: version
+            type: string
+            description: Which chart version to fetch
             required: false
         responses:
           200: # normal success
@@ -1475,6 +1490,39 @@ version: v1alpha3
             type: string
             description: User's authentication token
             required: true
+        responses:
+          200:
+            description: Success
+            body:
+              application/json:
+                type: !include AppInstallResultSchema.json
+          403:
+            description: Authentication/authorization error
+            body:
+              application/json:
+                type: !include ErrorResultSchema.json
+          404:
+            description: Instance not found error
+            body:
+              application/json:
+                type: !include ErrorResultSchema.json
+    /update:
+      put:
+        description: update application instance
+        queryParameters:
+          token:
+            displayName: Access Token
+            type: string
+            description: User's authentication token
+            required: true
+          version:
+            displayName: version
+            type: string
+            description: Which chart version to fetch
+            required: false
+        body:
+          application/json:
+            type: !include InstanceUpdateRequestSchema.json
         responses:
           200:
             description: Success

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -641,7 +641,7 @@ crow::response updateApplicationInstance(PersistentStore& store, const crow::req
 	if(body["chartVersion"].IsString())
 		chartVersion = body["chartVersion"].GetString();
 
-	auto helmSearchResult = runCommand("helm",{"inspect","values",instance.application, "--version", chartVersion, "-o", "json"});
+	auto helmSearchResult = runCommand("helm",{"inspect","values",instance.application, "--version", chartVersion});
 	if(helmSearchResult.status){
 		log_error("Command failed: helm search " << (instance.application) << ": [exit] " << helmSearchResult.status << " [err] " << helmSearchResult.error << " [out] " << helmSearchResult.output);
 		return crow::response(500, generateError("Unable to fetch application version"));

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -641,6 +641,12 @@ crow::response updateApplicationInstance(PersistentStore& store, const crow::req
 	if(body["chartVersion"].IsString())
 		chartVersion = body["chartVersion"].GetString();
 
+	auto commandResult = runCommand("helm",{"search","repo",instance.application, "--version", chartVersion, "-o", "json"});
+	if(commandResult.status){
+		log_error("Command failed: helm search " << (instance.application) << ": [exit] " << commandResult.status << " [err] " << commandResult.error << " [out] " << commandResult.output);
+		return crow::response(500, generateError("Unable to fetch application version"));
+	}
+
 	std::string resultMessage;
 	
 	auto clusterConfig=store.configPathForCluster(cluster.id);

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -641,7 +641,7 @@ crow::response updateApplicationInstance(PersistentStore& store, const crow::req
 	if(body["chartVersion"].IsString())
 		chartVersion = body["chartVersion"].GetString();
 
-	auto helmSearchResult = runCommand("helm",{"search","repo",instance.application, "--version", chartVersion, "-o", "json"});
+	auto helmSearchResult = runCommand("helm",{"inspect","values",instance.application, "--version", chartVersion, "-o", "json"});
 	if(helmSearchResult.status){
 		log_error("Command failed: helm search " << (instance.application) << ": [exit] " << helmSearchResult.status << " [err] " << helmSearchResult.error << " [out] " << helmSearchResult.output);
 		return crow::response(500, generateError("Unable to fetch application version"));

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -603,6 +603,202 @@ std::string deleteApplicationInstance(PersistentStore& store, const ApplicationI
 }
 }
 
+crow::response updateApplicationInstance(PersistentStore& store, const crow::request& req, const std::string& instanceID){
+	const User user=authenticateUser(store, req.url_params.get("token"));
+	log_info(user << " requested to update " << instanceID << " from " << req.remote_endpoint);
+	if(!user)
+		return crow::response(403,generateError("Not authorized"));
+	
+	auto instance=store.getApplicationInstance(instanceID);
+	if(!instance)
+		return crow::response(404,generateError("Application instance not found"));
+	//only admins or members of the Group which owns an instance may restart it
+	if(!user.admin && !store.userInGroup(user.id,instance.owningGroup))
+		return crow::response(403,generateError("Not authorized"));
+		
+	const Group group=store.getGroup(instance.owningGroup);
+	if(!group)
+		return crow::response(500,generateError("Invalid Group"));
+	const Cluster cluster=store.getCluster(instance.cluster);
+	if(!cluster)
+		return crow::response(500,generateError("Invalid Cluster"));
+
+	rapidjson::Document body;
+	try{
+		body.Parse(req.body.c_str());
+	}catch(std::runtime_error& err){
+		return crow::response(400,generateError("Invalid JSON in request body"));
+	}
+	if(body.IsNull())
+		return crow::response(400,generateError("Invalid JSON in request body"));
+
+	if(!body["configuration"].IsString())
+		return crow::response(400,generateError("Incorrect type for configuration"));
+
+	instance.config=body["configuration"].GetString();
+
+	std::string chartVersion = "";
+	if(body["chartVersion"].IsString())
+		chartVersion = body["chartVersion"].GetString();
+
+	std::string resultMessage;
+	
+	auto clusterConfig=store.configPathForCluster(cluster.id);
+	//TODO: it would be good to detect if there is nothing to stop and proceed 
+	//      with restarting in that case
+	log_info("Stopping old " << instance);
+	try{
+		auto systemNamespace=store.getCluster(instance.cluster).systemNamespace;
+		std::vector<std::string> deleteArgs={"delete",instance.name};
+		unsigned int helmMajorVersion=kubernetes::getHelmMajorVersion();
+		std::string notFoundMsg;
+		if(helmMajorVersion==2){
+			deleteArgs.insert(deleteArgs.begin()+1,"--purge");
+			notFoundMsg="\""+instance.name+"\" not found";
+		}
+		else if(helmMajorVersion==3){
+			deleteArgs.push_back("--namespace");
+			deleteArgs.push_back(group.namespaceName());
+			notFoundMsg=instance.name+": release: not found";
+		}
+		auto helmResult=kubernetes::helm(*clusterConfig,systemNamespace,deleteArgs);
+	
+		if((helmResult.status || 
+		    (helmResult.output.find("release \""+instance.name+"\" deleted")==std::string::npos && 
+		     helmResult.output.find("release \""+instance.name+"\" uninstalled")==std::string::npos))
+		   && helmResult.error.find(notFoundMsg)==std::string::npos){
+			std::string message="helm delete failed: " + helmResult.error;
+			log_error(message);
+			return crow::response(500,generateError(message));
+		}
+	}
+	catch(std::runtime_error& e){
+		return crow::response(500,generateError(std::string("Failed to delete instance using helm: ")+e.what()));
+	}
+	
+	log_info("Waiting to ensure that all previous objects from " << instance << " have been deleted");
+	std::chrono::seconds maxTime(120), elapsedTime(0), maxPollDelay(10), pollDelay(1);
+	while(elapsedTime<maxTime){
+		pollDelay+=pollDelay;
+		if(pollDelay>maxPollDelay)
+			pollDelay=maxPollDelay;
+		std::this_thread::sleep_for(pollDelay);
+		try{
+			auto objsResult=kubernetes::kubectl(*clusterConfig,{"get","all","-l release="+instance.name,"-n",group.namespaceName(),"-o=json"});
+			if(objsResult.status){
+				log_error("Failed to check for deleted instance objects: " << objsResult.error);
+				resultMessage+="Failed to check whether objects from old instance are fully deleted; reinstall may fail\n";
+				break;
+			}
+			rapidjson::Document objData;
+			try{
+				objData.Parse(objsResult.output.c_str());
+			}
+			catch(std::runtime_error& err){
+				log_error("Unable to parse kubectl output for " << "get all -l release=" << instance.name << " -n" << group.namespaceName() << " -o=json");
+			}
+			//check whether any objects remain
+			if(objData.HasMember("items") && objData["items"].IsArray() && objData["items"].Empty())
+				break;
+		}
+		catch(std::runtime_error& e){
+			log_error("Failed to check for deleted instance objects: " << e.what());
+			resultMessage+="[Warning] Failed to check whether objects from old instance are fully deleted; reinstall may fail\n";
+			break;
+		}
+		//We only count up the time we deliberately waited, which will miss any 
+		//latency added by kubernetes. This could be accounted for if necessary.
+		elapsedTime+=pollDelay;
+	}
+	if(elapsedTime>=maxTime){
+		log_warn("Object deletion check timeout reached; proceeding with reinstall anyway");
+		resultMessage+="[Warning] Object deletion check timeout reached; proceeding with reinstall anyway\n";
+	}
+	
+	log_info("Starting new " << instance);
+	//write configuration to a file for helm's benefit
+	FileHandle instanceConfig=makeTemporaryFile(instance.id);
+	{
+		std::ofstream outfile(instanceConfig.path());
+		outfile << instance.config;
+		if(!outfile){
+			log_error("Failed to write instance configuration to " << instanceConfig.path());
+			return crow::response(500,generateError("Failed to write instance configuration to disk"));
+		}
+	}
+	std::string additionalValues=internal::assembleExtraHelmValues(store,cluster,instance);
+	
+	try{
+		kubernetes::kubectl_create_namespace(*clusterConfig, group);
+	}
+	catch(std::runtime_error& err){
+		store.removeApplicationInstance(instance.id);
+		return crow::response(500,generateError(err.what()));
+	}
+
+	std::vector<std::string> installArgs={"install",
+	  instance.name,
+	  instance.application,
+	   "--namespace",group.namespaceName(),
+	   "--values",instanceConfig.path(),
+	   "--set",additionalValues,
+	   "--version",chartVersion,
+	   };
+	unsigned int helmMajorVersion=kubernetes::getHelmMajorVersion();
+	if(helmMajorVersion==2){
+		installArgs.insert(installArgs.begin()+1,"--name");
+		installArgs.push_back("--tiller-namespace");
+		installArgs.push_back(cluster.systemNamespace);
+	}
+	   
+	auto commandResult=runCommand("helm",installArgs,{{"KUBECONFIG",*clusterConfig}});
+	if(commandResult.status || 
+	   (commandResult.output.find("STATUS: DEPLOYED")==std::string::npos &&
+	    commandResult.output.find("STATUS: deployed")==std::string::npos)){
+		std::string errMsg="Failed to start application instance with helm:\n"+commandResult.error+"\n system namespace: "+cluster.systemNamespace;
+		log_error(errMsg);
+		//helm will (unhelpfully) keep broken 'releases' around, so clean up here
+		std::vector<std::string> deleteArgs={"delete",instance.name,"--namespace",group.namespaceName()};
+		if(kubernetes::getHelmMajorVersion()==2)
+			deleteArgs.insert(deleteArgs.begin()+1,"--purge");
+		auto helmResult=kubernetes::helm(*clusterConfig,cluster.systemNamespace,deleteArgs);
+		//TODO: include any other error information?
+		if(!resultMessage.empty())
+			errMsg+="\n"+resultMessage;
+		return crow::response(500,generateError(errMsg));
+	}
+	log_info("Updated " << instance << " on " << cluster << " on behalf of " << user);
+	
+	rapidjson::Document result(rapidjson::kObjectType);
+	rapidjson::Document::AllocatorType& alloc = result.GetAllocator();
+	
+	result.AddMember("apiVersion", "v1alpha3", alloc);
+	result.AddMember("kind", "Configuration", alloc);
+	rapidjson::Value metadata(rapidjson::kObjectType);
+	metadata.AddMember("id", instance.id, alloc);
+	metadata.AddMember("name", instance.name, alloc);
+	//TODO: not including this data is non-compliant with the spec, but it is never used
+	/*if(lines.size()>1){
+		auto cols = string_split_columns(lines[1], '\t');
+		if(cols.size()>3){
+			metadata.AddMember("revision", cols[1], alloc);
+			metadata.AddMember("updated", cols[2], alloc);
+		}
+	}
+	if(!metadata.HasMember("revision")){
+		metadata.AddMember("revision", "?", alloc);
+		metadata.AddMember("updated", "?", alloc);
+	}*/
+	metadata.AddMember("application", instance.application, alloc);
+	metadata.AddMember("group", group.id, alloc);
+	result.AddMember("metadata", metadata, alloc);
+	//TODO: not including this data is non-compliant with the spec, but it is never used
+	//result.AddMember("status", "DEPLOYED", alloc);
+	result.AddMember("message", resultMessage, alloc);
+	
+	return crow::response(to_string(result));	
+}
+
 crow::response restartApplicationInstance(PersistentStore& store, const crow::request& req, const std::string& instanceID){
 	const User user=authenticateUser(store, req.url_params.get("token"));
 	log_info(user << " requested to restart " << instanceID << " from " << req.remote_endpoint);

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -767,6 +767,11 @@ crow::response updateApplicationInstance(PersistentStore& store, const crow::req
 			errMsg+="\n"+resultMessage;
 		return crow::response(500,generateError(errMsg));
 	}
+
+	// Not sure if this is the best way to handle updating db records
+	store.removeApplicationInstance(instanceID);
+	store.addApplicationInstance(instance);
+
 	log_info("Updated " << instance << " on " << cluster << " on behalf of " << user);
 	
 	rapidjson::Document result(rapidjson::kObjectType);

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -641,9 +641,9 @@ crow::response updateApplicationInstance(PersistentStore& store, const crow::req
 	if(body["chartVersion"].IsString())
 		chartVersion = body["chartVersion"].GetString();
 
-	auto commandResult = runCommand("helm",{"search","repo",instance.application, "--version", chartVersion, "-o", "json"});
-	if(commandResult.status){
-		log_error("Command failed: helm search " << (instance.application) << ": [exit] " << commandResult.status << " [err] " << commandResult.error << " [out] " << commandResult.output);
+	auto helmSearchResult = runCommand("helm",{"search","repo",instance.application, "--version", chartVersion, "-o", "json"});
+	if(helmSearchResult.status){
+		log_error("Command failed: helm search " << (instance.application) << ": [exit] " << helmSearchResult.status << " [err] " << helmSearchResult.error << " [out] " << helmSearchResult.output);
 		return crow::response(500, generateError("Unable to fetch application version"));
 	}
 

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -2237,7 +2237,7 @@ void Client::updateInstance(const InstanceUpdateOptions& opt){
 			std::cout << resultJSON["message"].GetString() << std::endl;
 	} else if (response.status==404) {
 		std::cerr << "Instance not found" << std::endl;
-		retryInstanceCommandWithFixup(&Client::restartInstance, opt);
+		retryInstanceCommandWithFixup(&Client::updateInstance, opt);
 		return;
 	} else{
 		std::cerr << "Failed to update instance " << opt.instanceID;

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -2196,7 +2196,7 @@ void Client::updateInstance(const InstanceUpdateOptions& opt){
 	ProgressToken progress(pman_,"Restarting instance...");
 	if(!verifyInstanceID(opt.instanceID)) {
 		std::cerr << "The instance update command requires an instance ID, not a name" << std::endl;
-		retryInstanceCommandWithFixup(&Client::restartInstance, opt);
+		retryInstanceCommandWithFixup(&Client::updateInstance, opt);
 		return;
 	}
 

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -2164,7 +2164,7 @@ void Client::getInstanceInfo(const InstanceOptions& opt){
 void Client::restartInstance(const InstanceOptions& opt){
 	ProgressToken progress(pman_,"Restarting instance...");
 	if(!verifyInstanceID(opt.instanceID)) {
-		std::cerr << "The instance info command requires an instance ID, not a name" << std::endl;
+		std::cerr << "The instance restart command requires an instance ID, not a name" << std::endl;
 		retryInstanceCommandWithFixup(&Client::restartInstance, opt);
 		return;
 	}
@@ -2192,10 +2192,64 @@ void Client::restartInstance(const InstanceOptions& opt){
 	}
 }
 
+void Client::updateInstance(const InstanceUpdateOptions& opt){
+	ProgressToken progress(pman_,"Restarting instance...");
+	if(!verifyInstanceID(opt.instanceID)) {
+		std::cerr << "The instance update command requires an instance ID, not a name" << std::endl;
+		retryInstanceCommandWithFixup(&Client::restartInstance, opt);
+		return;
+	}
+
+	std::string configuration;
+	if(!opt.configPath.empty()){
+		//read in user-specified configuration
+		std::ifstream confFile(opt.configPath);
+		if(!confFile)
+			throw std::runtime_error("Unable to read application instance configuration from "+opt.configPath);
+		std::string line;
+		while(std::getline(confFile,line))
+			configuration+=line+"\n";
+	}
+
+	rapidjson::Document request(rapidjson::kObjectType);
+	rapidjson::Document::AllocatorType& alloc = request.GetAllocator();
+
+	request.AddMember("apiVersion", "v1alpha3", alloc);
+	request.AddMember("configuration", rapidjson::StringRef(configuration.c_str()), alloc);
+	request.AddMember("chartVersion", rapidjson::StringRef(opt.chartVersion.c_str()), alloc);
+
+	auto url=makeURL("instances/"+opt.instanceID+"/update");
+
+	rapidjson::StringBuffer buffer;
+	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+	request.Accept(writer);
+
+	auto response=httpRequests::httpPut(url,buffer.GetString(),defaultOptions());
+	if(response.status==200){
+		std::cout << "Successfully updated instance " << opt.instanceID << std::endl;
+		
+		rapidjson::Document resultJSON;
+		resultJSON.Parse(response.body.c_str());
+		if(resultJSON.IsObject()
+		  && resultJSON.HasMember("message") 
+		  && resultJSON["message"].IsString()
+		  && resultJSON["message"].GetStringLength()>0)
+			std::cout << resultJSON["message"].GetString() << std::endl;
+	} else if (response.status==404) {
+		std::cerr << "Instance not found" << std::endl;
+		retryInstanceCommandWithFixup(&Client::restartInstance, opt);
+		return;
+	} else{
+		std::cerr << "Failed to update instance " << opt.instanceID;
+		showError(response.body);
+		throw OperationFailed();
+	}
+}
+
 void Client::deleteInstance(const InstanceDeleteOptions& opt){
 	ProgressToken progress(pman_,"Deleting instance...");
 	if(!verifyInstanceID(opt.instanceID)) {
-		std::cerr << "The instance info command requires an instance ID, not a name" << std::endl;
+		std::cerr << "The instance delete command requires an instance ID, not a name" << std::endl;
 		retryInstanceCommandWithFixup(&Client::deleteInstance, opt);
 		return;
 	}

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -2193,7 +2193,7 @@ void Client::restartInstance(const InstanceOptions& opt){
 }
 
 void Client::updateInstance(const InstanceUpdateOptions& opt){
-	ProgressToken progress(pman_,"Restarting instance...");
+	ProgressToken progress(pman_,"Updating instance...");
 	if(!verifyInstanceID(opt.instanceID)) {
 		std::cerr << "The instance update command requires an instance ID, not a name" << std::endl;
 		retryInstanceCommandWithFixup(&Client::updateInstance, opt);

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -382,6 +382,15 @@ void registerInstanceRestart(CLI::App& parent, Client& client){
     restart->callback([&client,restOpt](){ client.restartInstance(*restOpt); });
 }
 
+void registerInstanceUpdate(CLI::App& parent, Client& client){
+	auto updateOpt = std::make_shared<InstanceUpdateOptions>();
+    auto update = parent.add_subcommand("update", "Stop and restart a deployed instance with a new configuration");
+	update->add_option("instance", updateOpt->instanceID, "The ID of the instance")->required();
+	update->add_option("--version", updateOpt->chartVersion, "The application chart version to use");
+	install->add_option("--conf", updateOpt->configPath, "File containing configuration for the instance")->required();
+    update->callback([&client,updateOpt](){ client.updateInstance(*updateOpt); });
+}
+
 void registerInstanceDelete(CLI::App& parent, Client& client){
 	auto delOpt = std::make_shared<InstanceDeleteOptions>();
     auto del = parent.add_subcommand("delete", "Destroy an application instance");
@@ -421,6 +430,7 @@ void registerInstanceCommands(CLI::App& parent, Client& client){
 	registerInstanceDelete(*inst, client);
 	registerInstanceFetchLogs(*inst, client);
 	registerInstanceScale(*inst, client);
+	registerInstanceUpdate(*inst, client);
 }
 
 void registerSecretList(CLI::App& parent, Client& client){

--- a/src/client/slate_client.cpp
+++ b/src/client/slate_client.cpp
@@ -387,7 +387,7 @@ void registerInstanceUpdate(CLI::App& parent, Client& client){
     auto update = parent.add_subcommand("update", "Stop and restart a deployed instance with a new configuration");
 	update->add_option("instance", updateOpt->instanceID, "The ID of the instance")->required();
 	update->add_option("--version", updateOpt->chartVersion, "The application chart version to use");
-	install->add_option("--conf", updateOpt->configPath, "File containing configuration for the instance")->required();
+	update->add_option("--conf", updateOpt->configPath, "File containing configuration for the instance")->required();
     update->callback([&client,updateOpt](){ client.updateInstance(*updateOpt); });
 }
 

--- a/src/slate_service.cpp
+++ b/src/slate_service.cpp
@@ -593,6 +593,8 @@ int main(int argc, char* argv[]){
 	  [&](const crow::request& req, const std::string& iID){ return getApplicationInstanceScale(store,req,iID); });
 	CROW_ROUTE(server, "/v1alpha3/instances/<string>/scale").methods("PUT"_method)(
 	  [&](const crow::request& req, const std::string& iID){ return scaleApplicationInstance(store,req,iID); });
+	CROW_ROUTE(server, "/v1alpha3/instances/<string>/update").methods("PUT"_method)(
+	  [&](const crow::request& req, const std::string& iID){ return updateApplicationInstance(store,req,iID); });
 	
 	// == Secret commands ==
 	CROW_ROUTE(server, "/v1alpha3/secrets").methods("GET"_method)(


### PR DESCRIPTION
Enables updates and rollback of slate application instance configuration and version. A new route is added to the SLATE REST API

`v1alpha3/instances/<instanceID>/update`