### PR TITLE
Update RBAC to allow `kubectl get ingresses`

### DIFF
--- a/resources/federation-deployment.yaml
+++ b/resources/federation-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nrp-controller
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: nrp-controller
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: nrp-controller
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: nrp-controller
+  name: nrp-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: nrp-controller
+  template:
+    metadata:
+      labels:
+        k8s-app: nrp-controller
+    spec:
+      serviceAccountName: nrp-controller
+      containers:
+      - name: nrp-controller
+        image: slateci/nrp-controller:latest
+        imagePullPolicy: Always

--- a/resources/federation-role.yaml
+++ b/resources/federation-role.yaml
@@ -1,0 +1,229 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: federation-cluster
+  labels:
+    slate-federation-role-version: "v1"
+rules:
+- apiGroups:
+  - "nrp-nautilus.io"
+  resources:
+  - clusternamespaces
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - secrets
+  - serviceaccounts
+  - services
+  - services/proxy
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - bindings
+  - events
+  - limitranges
+  - namespaces/status
+  - pods/log
+  - pods/status
+  - replicationcontrollers/status
+  - resourcequotas
+  - resourcequotas/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - impersonate
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - replicasets
+  - replicasets/scale
+  - statefulsets
+  - statefulsets/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - ingresses
+  - networkpolicies
+  - replicasets
+  - replicasets/scale
+  - replicationcontrollers/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - localsubjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: federation-cluster-global
+  labels:
+    slate-federation-role-version: "v1"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - nodes
+  - priorityclasses
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/resources/federation-role.yaml
+++ b/resources/federation-role.yaml
@@ -163,6 +163,7 @@ rules:
   - networking.k8s.io
   resources:
   - networkpolicies
+  - ingresses
   verbs:
   - create
   - delete

--- a/src/client/ClusterRegistration.cpp
+++ b/src/client/ClusterRegistration.cpp
@@ -16,7 +16,10 @@ void Client::ensureNRPController(const std::string& configPath, bool assumeYes){
 	const static std::string controllerRepo="https://gitlab.com/ucsd-prp/nrp-controller";
 	//const static std::string controllerDeploymentURL="https://gitlab.com/ucsd-prp/nrp-controller/raw/master/deploy.yaml";
 	//const static std::string federationRoleURL="https://gitlab.com/ucsd-prp/nrp-controller/raw/master/federation-role.yaml";
-	const static std::string controllerDeploymentURL="https://jenkins.slateci.io/artifacts/test/federation-deployment.yaml";
+	// Old controller deployment URL - was hosted on Jenkins server
+	// const static std::string controllerDeploymentURL="https://jenkins.slateci.io/artifacts/test/federation-deployment.yaml";
+	// New controller deployment URL - hosted on GitHub with source code
+	const static std::string controllerDeploymentURL="https://raw.githubusercontent.com/slateci/slate-client-server/master/resources/federation-deployment.yaml";
 	
 	std::cout << "Checking NRP-controller status..." << std::endl;
 	auto result=runCommand("kubectl",{"get","deployments","-n","kube-system","--kubeconfig",configPath});

--- a/src/client/cluster_components/FederationRBAC.cpp
+++ b/src/client/cluster_components/FederationRBAC.cpp
@@ -5,7 +5,11 @@
 #include <Process.h>
 #include <Utilities.h>
 
-const std::string Client::federationRoleURL="https://jenkins.slateci.io/artifacts/test/federation-role.yaml";
+
+// Old URL - hosted on Jenkins build server
+// const std::string Client::federationRoleURL="https://jenkins.slateci.io/artifacts/test/federation-role.yaml";
+// New URL - hosted with source code
+const std::string Client::federationRoleURL="https://raw.githubusercontent.com/slateci/slate-client-server/master/resources/federation-role.yaml";
 
 Client::ClusterComponent::ComponentStatus Client::checkFederationRBAC(const std::string& configPath, const std::string& systemNamespace) const{
 	static const std::string rbacVersionTag="slate-federation-role-version";

--- a/test/DBServer.cpp
+++ b/test/DBServer.cpp
@@ -211,7 +211,7 @@ int main(){
 	{ //make sure kubernetes is in the right state for federation
 		std::cout << "Installing federation role" << std::endl;
 		auto res=runCommand("kubectl",
-		  {"apply","-f","https://jenkins.slateci.io/artifacts/test/federation-role.yaml"});
+		  {"apply","-f","https://raw.githubusercontent.com/slateci/slate-client-server/master/resources/federation-role.yaml"});
 		if(res.status){
 			std::cerr << "Unable to deploy federation role: " << res.error << std::endl;
 			return(1);
@@ -219,7 +219,7 @@ int main(){
 		
 		std::cout << "Installing federation controller" << std::endl;
 		res=runCommand("kubectl",
-		  {"apply","-f","https://jenkins.slateci.io/artifacts/test/federation-deployment.yaml"});
+		  {"apply","-f","https://raw.githubusercontent.com/slateci/slate-client-server/master/resources/federation-deployment.yaml"});
 		if(res.status){
 			std::cerr << "Unable to deploy federation controller: " << res.error << std::endl;
 			return(1);


### PR DESCRIPTION
This PR moves the `ingresses` privilege to the proper place to match k8s API changes. 
Additionally, it moves two yaml files from Jenkins to GitHub.