### PR TITLE
Update VolumeClaimCommands.cpp (Closes #154)

### DIFF
--- a/src/VolumeClaimCommands.cpp
+++ b/src/VolumeClaimCommands.cpp
@@ -89,14 +89,14 @@ crow::response listVolumeClaims(PersistentStore& store, const crow::request& req
 
 		// Add volume status from K8s (Bound, Pending...)
 		if((volumeStatus.IsObject() && volumeStatus.HasMember("status"))
-		   && volumeStatus["status"].IsObject() && volumeStatus["status"].HasMember("phase")){
-		volumeData.AddMember("status", volumeStatus["status"]["phase"], alloc);
-		volumeResult.AddMember("metadata", volumeData, alloc);
-		resultItems.PushBack(volumeResult, alloc);
+	  	   && volumeStatus["status"].IsObject() && volumeStatus["status"].HasMember("phase")){
+			volumeData.AddMember("status", volumeStatus["status"]["phase"], alloc);
 		}
 		else{
 			volumeData.AddMember("status", "unknown", alloc);
 		}
+		volumeResult.AddMember("metadata", volumeData, alloc);
+		resultItems.PushBack(volumeResult, alloc);
 	}
 	result.AddMember("items", resultItems, alloc);
 

--- a/src/VolumeClaimCommands.cpp
+++ b/src/VolumeClaimCommands.cpp
@@ -88,9 +88,15 @@ crow::response listVolumeClaims(PersistentStore& store, const crow::request& req
 		} 
 
 		// Add volume status from K8s (Bound, Pending...)
+		if((volumeStatus.IsObject() && volumeStatus.HasMember("status"))
+		   && volumeStatus["status"].IsObject() && volumeStatus["status"].HasMember("phase")){
 		volumeData.AddMember("status", volumeStatus["status"]["phase"], alloc);
 		volumeResult.AddMember("metadata", volumeData, alloc);
 		resultItems.PushBack(volumeResult, alloc);
+		}
+		else{
+			volumeData.AddMember("status", "unknown", alloc);
+		}
 	}
 	result.AddMember("items", resultItems, alloc);
 


### PR DESCRIPTION
Ensures that a volume can be listed before adding an entry to the result, else it sets volumeStatus to "unkown".