### PR TITLE
Fix hanging unit tests for cluster and group deletion

### DIFF
--- a/test/TestClusterDeletion.cpp
+++ b/test/TestClusterDeletion.cpp
@@ -293,6 +293,8 @@ TEST(DeletingClusterHasCascadingDeletion){
 	out << conf;
 	out.close();
 	std::vector<std::string> args = {"get", "namespaces"};
+	startReaper();
 	auto names = kubernetes::kubectl("./testconfigdeletion.yaml", args);
+	stopReaper();
 	ENSURE_EQUAL(names.output.find("slate-group-testgroup1"), std::string::npos, "Cluster deletion should delete associated namespaces");
 }

--- a/test/TestGroupDeletion.cpp
+++ b/test/TestGroupDeletion.cpp
@@ -260,6 +260,8 @@ TEST(DeletingGroupHasCascadingDeletion){
 	out << conf;
 	out.close();
 	std::vector<std::string> args = {"get", "namespaces"};
+	startReaper();
 	auto names = kubernetes::kubectl("./testconfigdeletion.yaml", args);
+	stopReaper();
 	ENSURE_EQUAL(names.output.find("slate-group-testgroup1"), std::string::npos, "VO deletion should delete associated namespaces");
 }


### PR DESCRIPTION
Starts and stops process reaper before and after kubectl call in `DeletingGroupHasCascadingDeletion` and `DeletingClusterHasCascadingDeletion`. This appears to fix the issue (tests are now passing as expected), but reviewers are encouraged to pull this branch and check that it now passes for themselves, too. As a minor forewarning, these tests take longer than 30 seconds to complete but in my experience should take no more than 35; so be sure to wait about that long while checking the tests yourself.

Closes #148 