### PR TITLE
Fixes for tests 33 and 34

### DIFF
--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -531,13 +531,16 @@ crow::response installApplicationImpl(PersistentStore& store, const User& user, 
 }
 
 crow::response installApplication(PersistentStore& store, const crow::request& req, const std::string& appName){
-	auto repo=selectRepo(req);
-	std::string repoName=getRepoName(repo);
 	//authenticate
 	const User user=authenticateUser(store, req.url_params.get("token"));
-	if(!user)
+	if(!user) {
+		log_info("An unauthorized user attempted to install an instance of " << appName << " from " << req.remote_endpoint);
 		return crow::response(403,generateError("Not authorized"));
+	}
 	
+	auto repo=selectRepo(req);
+	std::string repoName=getRepoName(repo);
+
 	if(appName.find('\'')!=std::string::npos)
 		return crow::response(400,generateError("Application names cannot contain single quote characters"));
 	//collect data out of JSON body

--- a/test/TestAdHocApplicationInstall.cpp
+++ b/test/TestAdHocApplicationInstall.cpp
@@ -633,7 +633,7 @@ data:
 		request.AddMember("chart",chart,alloc);
 		request.AddMember("configuration", "", alloc);
 		auto instResp=httpPost(tc.getAPIServerURL()+"/"+currentAPIVersion+"/apps/ad-hoc?test&token="+adminKey,to_string(request));
-		ENSURE_EQUAL(instResp.status,500,
+		ENSURE_EQUAL(instResp.status,400,
 		             "Application install request with malformed chart (missing templates) should be rejected");
 	}
 	


### PR DESCRIPTION
Does two things: 1.) It reorders the way installs are handled in regular installations and 2.) includes a check for the templates directory in tarball installations. (Changed response to error code 400 instead of expecting error code 500 when this happens).

These should fix the last few broken tests. As always you are encouraged to check if these fixes work for you locally. There may be more broken tests on your end, however, these were the only two that didn't work for @cnweaver after my last PR which leads me to think other failures are related to environmental issues and not actual bugs with the server.