### PR TITLE
Adding 'skip cascading deletion' feature when force deleting unreachable cluster and creating a new test

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.associations": {
+        "*.ipp": "cpp",
+        "array": "cpp",
+        "regex": "cpp",
+        "stdexcept": "cpp"
+    }
+}

--- a/include/ApplicationInstanceCommands.h
+++ b/include/ApplicationInstanceCommands.h
@@ -39,7 +39,7 @@ namespace internal{
 	///\return a string describing the error which has occured, or an empty 
 	///        string indicating success
 	std::string deleteApplicationInstance(PersistentStore& store, const ApplicationInstance& instance, bool force);
-	std::string deleteApplicationInstanceFromStore(PersistentStore& store, const ApplicationInstance& instance, bool force);
+	std::string deleteApplicationInstanceFromStore(PersistentStore& store, const ApplicationInstance& instance);
 }
 
 #endif //SLATE_APPLICATION_INSTANCE_COMMANDS_H

--- a/include/PersistentStore.h
+++ b/include/PersistentStore.h
@@ -163,8 +163,6 @@ public:
 	///Change the cluster cache validity time
 	///\param value the time in seconds before cached data is no longer valid
 	void setClusterCacheValidity(std::chrono::seconds value);
-
-	int getCacheValidity();
 	
 	///Store a record for a new user
 	///\return Whether the user record was successfully added to the database

--- a/include/PersistentStore.h
+++ b/include/PersistentStore.h
@@ -288,7 +288,7 @@ public:
 	///Store a record for a new cluster
 	///\param cluster the new cluster
 	///\return Whether the record was successfully added to the database
-	bool addCluster(const Cluster& cluster, bool reduceCacheValidity=false);
+	bool addCluster(const Cluster& cluster, int cacheExpirationTime = 0);
 	
 	///Delete a cluster record
 	///\param cID the ID of the cluster to delete

--- a/include/PersistentStore.h
+++ b/include/PersistentStore.h
@@ -162,7 +162,7 @@ public:
 
 	///Change the cluster cache validity time
 	///\param value the time in seconds before cached data is no longer valid
-	void setCacheValidity(std::chrono::seconds value);
+	void setClusterCacheValidity(std::chrono::seconds value);
 
 	int getCacheValidity();
 	
@@ -288,7 +288,7 @@ public:
 	///Store a record for a new cluster
 	///\param cluster the new cluster
 	///\return Whether the record was successfully added to the database
-	bool addCluster(const Cluster& cluster);
+	bool addCluster(const Cluster& cluster, bool reduceCacheValidity=false);
 	
 	///Delete a cluster record
 	///\param cID the ID of the cluster to delete

--- a/include/PersistentStore.h
+++ b/include/PersistentStore.h
@@ -159,6 +159,12 @@ public:
 	                std::string encryptionKeyFile,
 	                std::string appLoggingServerName,
 	                unsigned int appLoggingServerPort);
+
+	///Change the cluster cache validity time
+	///\param value the time in seconds before cached data is no longer valid
+	void setCacheValidity(std::chrono::seconds value);
+
+	int getCacheValidity();
 	
 	///Store a record for a new user
 	///\return Whether the user record was successfully added to the database
@@ -680,7 +686,7 @@ private:
 	cuckoohash_map<std::string,CacheRecord<Group>> groupByNameCache;
 	concurrent_multimap<std::string,CacheRecord<Group>> groupByUserCache;
 	///duration for which cached cluster records should remain valid
-	const std::chrono::seconds clusterCacheValidity;
+	std::chrono::seconds clusterCacheValidity;
 	slate_atomic<std::chrono::steady_clock::time_point> clusterCacheExpirationTime;
 	cuckoohash_map<std::string,CacheRecord<Cluster>> clusterCache;
 	cuckoohash_map<std::string,CacheRecord<Cluster>> clusterByNameCache;

--- a/include/SecretCommands.h
+++ b/include/SecretCommands.h
@@ -29,7 +29,7 @@ namespace internal{
 	///\return a string describing the error which has occured, or an empty 
 	///        string indicating success
 	std::string deleteSecret(PersistentStore& store, const Secret& secret, bool force);
-	std::string deleteSecretFromStore(PersistentStore& store, const Secret& secret, bool force);
+	std::string deleteSecretFromStore(PersistentStore& store, const Secret& secret);
 }
 
 #endif //SLATE_SECRET_COMMANDS_H

--- a/include/VolumeClaimCommands.h
+++ b/include/VolumeClaimCommands.h
@@ -26,7 +26,7 @@ namespace internal{
 	///\return a string describing the error which has occured, or an empty 
 	///        string indicating success
 	std::string deleteVolumeClaim(PersistentStore& store, const PersistentVolumeClaim& pvc, bool force);
-	std::string deleteVolumeClaimFromStore(PersistentStore& store, const PersistentVolumeClaim& pvc, bool force);
+	std::string deleteVolumeClaimFromStore(PersistentStore& store, const PersistentVolumeClaim& pvc);
 }
 
 #endif //SLATE_VOLUME_CLAIM_COMMANDS_H

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -595,13 +595,17 @@ std::string deleteApplicationInstance(PersistentStore& store, const ApplicationI
 		else
 			log_info("Forcing deletion of " << instance << " in spite of error");
 	}	
+	if(!store.removeApplicationInstance(instance.id)){
+		log_error("Failed to delete " << instance << " from persistent store");
+		return "Failed to delete instance from persistent store";
+	}
 	return "";
 }
 std::string deleteApplicationInstanceFromStore(PersistentStore& store, const ApplicationInstance& instance){
 	//remove from the database
 	if(!store.removeApplicationInstance(instance.id)){
 		log_error("Failed to delete " << instance << " from persistent store");
-		return "Failed to delete instance from database";
+		return "Failed to delete instance from persistent store";
 	}
 	return "";
 }

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -564,7 +564,7 @@ std::string deleteApplicationInstance(PersistentStore& store, const ApplicationI
 	log_info("Deleting " << instance);
 	//remove from kubernetes
 	try{
-		const Group group=store.getGroup(instance.owningGroup);
+		const Group group=store.getGroup(instance.owningGroup); 
 		auto configPath=store.configPathForCluster(instance.cluster);
 		auto systemNamespace=store.getCluster(instance.cluster).systemNamespace;
 		std::vector<std::string> deleteArgs={"delete",instance.name};

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -597,7 +597,7 @@ std::string deleteApplicationInstance(PersistentStore& store, const ApplicationI
 	}	
 	return "";
 }
-std::string deleteApplicationInstanceFromStore(PersistentStore& store, const ApplicationInstance& instance, bool force){
+std::string deleteApplicationInstanceFromStore(PersistentStore& store, const ApplicationInstance& instance){
 	//remove from the database
 	if(!store.removeApplicationInstance(instance.id)){
 		log_error("Failed to delete " << instance << " from persistent store");

--- a/src/ClusterCommands.cpp
+++ b/src/ClusterCommands.cpp
@@ -762,7 +762,7 @@ std::string deleteCluster(PersistentStore& store, const Cluster& cluster, bool f
 	if(clusterInfo.status ||
        clusterInfo.output.find("default")==std::string::npos){
 		reachable=false;
-		if(force)
+		if(force){
 			std::cout << "Cluster is unreachable: " 
 					  << "If the cluster still exists, objects may require manual deletion. "
 					  << "Are you sure you want to contine?  [y/n]";
@@ -770,7 +770,9 @@ std::string deleteCluster(PersistentStore& store, const Cluster& cluster, bool f
 			std::getline(std::cin,answer);
 			if(answer!="y" && answer!="Y")
 				throw std::runtime_error("Cluster deletion aborted");
-			log_info("Unable to contact " << cluster << ": Deleting records and skipping object deletion");
+			else
+				log_info("Unable to contact " << cluster << ": Deleting records and skipping object deletion");
+		}
 		else{
 			log_info("Unable to contact " << cluster << ": " << clusterInfo.error);
 			return "Cluster is unreachable";

--- a/src/ClusterCommands.cpp
+++ b/src/ClusterCommands.cpp
@@ -762,15 +762,19 @@ std::string deleteCluster(PersistentStore& store, const Cluster& cluster, bool f
 	if(clusterInfo.status ||
        clusterInfo.output.find("default")==std::string::npos){
 		reachable=false;
-		if(force)
-				log_info("Unable to contact " << cluster << ": Deleting records and skipping object deletion");
+		if(force){
+			log_info("Unable to contact " << cluster << ": Deleting records and skipping object deletion");
+			std::cout << "Unreachable: performing force deletion" << std::endl;
+		}
 		else{
 			log_info("Unable to contact " << cluster << ": " << clusterInfo.error);
 			return "Cluster is unreachable";
+			std::cout << "Unable to delete cluster: unreachable" << std::endl;
 		}
 	}
 	else{
 		log_info("Success contacting " << cluster);
+		std::cout << "Reachable: performing normal deletion" << std::endl;
 	}
 
 	// Delete any remaining instances that are present on the cluster

--- a/src/ClusterCommands.cpp
+++ b/src/ClusterCommands.cpp
@@ -407,8 +407,9 @@ crow::response createCluster(PersistentStore& store, const crow::request& req){
 	
 	log_info("Creating " << cluster);
 
-	if(body["metadata"].HasMember("reduceCacheValidity")){ //optional test configuration for short cache validity time
-		bool created=store.addCluster(cluster,true);
+	if(body["metadata"].HasMember("setCacheValidity")){ //optional configuration for cluster cache validity time
+		int seconds = body["metadata"]["setCacheValidity"].GetInt();
+		bool created=store.addCluster(cluster,seconds);
 		if(!created){
 			log_error("Failed to create " << cluster);
 			return crow::response(500,generateError("Cluster registration failed"));
@@ -416,7 +417,6 @@ crow::response createCluster(PersistentStore& store, const crow::request& req){
 	}
 	else{
 		bool created=store.addCluster(cluster);
-		std::cout << "--> Failure!" << std::endl;
 		if(!created){
 			log_error("Failed to create " << cluster);
 			return crow::response(500,generateError("Cluster registration failed"));

--- a/src/ClusterCommands.cpp
+++ b/src/ClusterCommands.cpp
@@ -407,8 +407,8 @@ crow::response createCluster(PersistentStore& store, const crow::request& req){
 	
 	log_info("Creating " << cluster);
 
-	if(body["metadata"].HasMember("setCacheValidity")){ //optional configuration for cluster cache validity time
-		int seconds = body["metadata"]["setCacheValidity"].GetInt();
+	if(body["metadata"].HasMember("setClusterCacheValidity")){ //optional configuration for cluster cache validity time
+		int seconds = body["metadata"]["setClusterCacheValidity"].GetInt();
 		bool created=store.addCluster(cluster,seconds);
 		if(!created){
 			log_error("Failed to create " << cluster);

--- a/src/ClusterCommands.cpp
+++ b/src/ClusterCommands.cpp
@@ -763,6 +763,13 @@ std::string deleteCluster(PersistentStore& store, const Cluster& cluster, bool f
        clusterInfo.output.find("default")==std::string::npos){
 		reachable=false;
 		if(force)
+			std::cout << "Cluster is unreachable: " 
+					  << "If the cluster still exists, objects may require manual deletion. "
+					  << "Are you sure you want to contine?  [y/n]"
+			std::string answer;
+			std::getline(std::cin,answer);
+			if(answer!="y" && answer!="Y")
+				throw std::runtime_error("Cluster deletion aborted");
 			log_info("Unable to contact " << cluster << ": Deleting records and skipping object deletion");
 		else{
 			log_info("Unable to contact " << cluster << ": " << clusterInfo.error);

--- a/src/ClusterCommands.cpp
+++ b/src/ClusterCommands.cpp
@@ -793,9 +793,6 @@ std::string deleteCluster(PersistentStore& store, const Cluster& cluster, bool f
 				std::string result=internal::deleteApplicationInstance(store,instance,force);
 				if(!force && !result.empty())
 					return "Failed to delete cluster due to failure deleting instance: "+result;
-				std::string resultData=internal::deleteApplicationInstanceFromStore(store,instance);
-				if(!force && !resultData.empty())
-					return "Failed to delete instance data: "+resultData;
 			}
 			else if(!reachable && force){
 				std::string resultData=internal::deleteApplicationInstanceFromStore(store,instance);
@@ -816,7 +813,7 @@ std::string deleteCluster(PersistentStore& store, const Cluster& cluster, bool f
 		if(reachable){
 		secretDeletions.emplace_back(std::async(std::launch::async,[&store,secret](){ return internal::deleteSecret(store,secret,/*force*/true); }));
 		}
-		if(reachable || !reachable && force){
+		if(!reachable && force){
 			secretDeletions.emplace_back(std::async(std::launch::async,[&store,secret](){ return internal::deleteSecretFromStore(store,secret); }));
 		}
 	}
@@ -827,7 +824,7 @@ std::string deleteCluster(PersistentStore& store, const Cluster& cluster, bool f
 		if(reachable){
 			volumeDeletions.emplace_back(std::async(std::launch::async,[&store,volume]() { return internal::deleteVolumeClaim(store, volume, true); }));
 		}
-		if(reachable || !reachable && force){
+		if(!reachable && force){
 			volumeDeletions.emplace_back(std::async(std::launch::async,[&store,volume]() { return internal::deleteVolumeClaimFromStore(store, volume); }));
 		}
 	}

--- a/src/ClusterCommands.cpp
+++ b/src/ClusterCommands.cpp
@@ -765,7 +765,7 @@ std::string deleteCluster(PersistentStore& store, const Cluster& cluster, bool f
 		if(force)
 			std::cout << "Cluster is unreachable: " 
 					  << "If the cluster still exists, objects may require manual deletion. "
-					  << "Are you sure you want to contine?  [y/n]"
+					  << "Are you sure you want to contine?  [y/n]";
 			std::string answer;
 			std::getline(std::cin,answer);
 			if(answer!="y" && answer!="Y")

--- a/src/ClusterCommands.cpp
+++ b/src/ClusterCommands.cpp
@@ -759,6 +759,8 @@ std::string deleteCluster(PersistentStore& store, const Cluster& cluster, bool f
     auto configPath=store.configPathForCluster(cluster.id);
     auto clusterInfo=kubernetes::kubectl(*configPath,{"get","serviceaccounts","-o=jsonpath={.items[*].metadata.name}"});
     bool reachable=true;
+	std::cout << "==============" << std::endl << "Current config:" << std::endl << cluster.config << std::endl;
+	std::cout << "Current cache validity: " << store.getCacheValidity() << std::endl << "==============" << std::endl;
 	if(clusterInfo.status ||
        clusterInfo.output.find("default")==std::string::npos){
 		reachable=false;

--- a/src/ClusterCommands.cpp
+++ b/src/ClusterCommands.cpp
@@ -813,14 +813,10 @@ std::string deleteCluster(PersistentStore& store, const Cluster& cluster, bool f
 	// Delete any remaining secrets present on the cluster
 	auto secrets=store.listSecrets("",cluster.id);
 	for (const Secret& secret : secrets){
-		//std::string result=internal::deleteSecret(store,secret,/*force*/true);
-		//if(!force && !result.empty())
-		//	return "Failed to delete cluster due to failure deleting secret: "+result;
 		if(reachable){
-			secretDeletions.emplace_back(std::async(std::launch::async,[&store,secret](){ return internal::deleteSecret(store,secret,/*force*/true); }));
-			secretDeletions.emplace_back(std::async(std::launch::async,[&store,secret](){ return internal::deleteSecretFromStore(store,secret,/*force*/true); }));
+		secretDeletions.emplace_back(std::async(std::launch::async,[&store,secret](){ return internal::deleteSecret(store,secret,/*force*/true); }));
 		}
-		else if(!reachable && force){
+		if(reachable || !reachable && force){
 			secretDeletions.emplace_back(std::async(std::launch::async,[&store,secret](){ return internal::deleteSecretFromStore(store,secret,/*force*/true); }));
 		}
 	}
@@ -831,7 +827,7 @@ std::string deleteCluster(PersistentStore& store, const Cluster& cluster, bool f
 		if(reachable){
 			volumeDeletions.emplace_back(std::async(std::launch::async,[&store,volume]() { return internal::deleteVolumeClaim(store, volume, true); }));
 		}
-		else if(!reachable && force){
+		if(reachable || !reachable && force){
 			volumeDeletions.emplace_back(std::async(std::launch::async,[&store,volume]() { return internal::deleteVolumeClaimFromStore(store, volume, true); }));
 		}
 	}

--- a/src/ClusterCommands.cpp
+++ b/src/ClusterCommands.cpp
@@ -793,12 +793,12 @@ std::string deleteCluster(PersistentStore& store, const Cluster& cluster, bool f
 				std::string result=internal::deleteApplicationInstance(store,instance,force);
 				if(!force && !result.empty())
 					return "Failed to delete cluster due to failure deleting instance: "+result;
-				std::string resultData=internal::deleteApplicationInstanceFromStore(store,instance,force);
+				std::string resultData=internal::deleteApplicationInstanceFromStore(store,instance);
 				if(!force && !resultData.empty())
 					return "Failed to delete instance data: "+resultData;
 			}
 			else if(!reachable && force){
-				std::string resultData=internal::deleteApplicationInstanceFromStore(store,instance,force);
+				std::string resultData=internal::deleteApplicationInstanceFromStore(store,instance);
 				if(!resultData.empty())
 					return "Failed to delete instance data: "+resultData;
 			}

--- a/src/ClusterCommands.cpp
+++ b/src/ClusterCommands.cpp
@@ -762,17 +762,8 @@ std::string deleteCluster(PersistentStore& store, const Cluster& cluster, bool f
 	if(clusterInfo.status ||
        clusterInfo.output.find("default")==std::string::npos){
 		reachable=false;
-		if(force){
-			std::cout << "Cluster is unreachable: " 
-					  << "If the cluster still exists, objects may require manual deletion. "
-					  << "Are you sure you want to contine?  [y/n]";
-			std::string answer;
-			std::getline(std::cin,answer);
-			if(answer!="y" && answer!="Y")
-				throw std::runtime_error("Cluster deletion aborted");
-			else
+		if(force)
 				log_info("Unable to contact " << cluster << ": Deleting records and skipping object deletion");
-		}
 		else{
 			log_info("Unable to contact " << cluster << ": " << clusterInfo.error);
 			return "Cluster is unreachable";

--- a/src/KubeInterface.cpp
+++ b/src/KubeInterface.cpp
@@ -22,18 +22,6 @@ commandResult kubectl(const std::string& configPath,
 	                     removeShellEscapeSequences(result.error),result.status};
 }
 
-commandResult minikube(const std::vector<std::string>& arguments){
-	std::vector<std::string> fullArgs;
-	std::copy(arguments.begin(),arguments.end(),std::back_inserter(fullArgs));
-	return runCommand("minikube",fullArgs);
-}
-
-commandResult systemctl(const std::vector<std::string>& arguments){
-	std::vector<std::string> fullArgs;
-	std::copy(arguments.begin(),arguments.end(),std::back_inserter(fullArgs));
-	return runCommand("systemctl",fullArgs);
-}
-
 #ifdef SLATE_SERVER
 void kubectl_create_namespace(const std::string& clusterConfig, const Group& group) {
 	std::string input=

--- a/src/PersistentStore.cpp
+++ b/src/PersistentStore.cpp
@@ -1070,6 +1070,14 @@ bool PersistentStore::addUser(const User& user){
 	return true;
 }
 
+void PersistentStore::setCacheValidity(std::chrono::seconds value) {
+	clusterCacheValidity = value;
+}
+
+int PersistentStore::getCacheValidity() {
+	return clusterCacheValidity.count();
+}
+
 User PersistentStore::getUser(const std::string& id){
 	//first see if we have this cached
 	{
@@ -2131,7 +2139,7 @@ bool PersistentStore::removeCluster(const std::string& cID){
 	return true;
 }
 
-bool PersistentStore::updateCluster(const Cluster& cluster){
+bool PersistentStore::updateCluster(const Cluster& cluster){  // <----- Here
 	using AV=Aws::DynamoDB::Model::AttributeValue;
 	using AVU=Aws::DynamoDB::Model::AttributeValueUpdate;
 	auto outcome=dbClient.UpdateItem(Aws::DynamoDB::Model::UpdateItemRequest()
@@ -2151,7 +2159,6 @@ bool PersistentStore::updateCluster(const Cluster& cluster){
 		log_error("Failed to update cluster record: " << err.GetMessage());
 		return false;
 	}
-	
 	//update caches
 	CacheRecord<Cluster> record(cluster,clusterCacheValidity);
 	replaceCacheRecord(clusterCache,cluster.id,record);

--- a/src/PersistentStore.cpp
+++ b/src/PersistentStore.cpp
@@ -1933,7 +1933,7 @@ SharedFileHandle PersistentStore::configPathForCluster(const std::string& cID){
 	return clusterConfigs.find(cID);
 }
 
-bool PersistentStore::addCluster(const Cluster& cluster, bool reduceCacheValidity){
+bool PersistentStore::addCluster(const Cluster& cluster, int cacheExpirationTime){
 	using Aws::DynamoDB::Model::AttributeValue;
 	auto request=Aws::DynamoDB::Model::PutItemRequest()
 	.WithTableName(clusterTableName)
@@ -1954,8 +1954,8 @@ bool PersistentStore::addCluster(const Cluster& cluster, bool reduceCacheValidit
 		return false;
 	}
 	//option to reduce cluster cache validity time for testing
-	if(reduceCacheValidity == true){
-		PersistentStore::setClusterCacheValidity(std::chrono::seconds(1));
+	if(cacheExpirationTime != 0){
+		PersistentStore::setClusterCacheValidity(std::chrono::seconds(cacheExpirationTime));
 	}
 
 	CacheRecord<Cluster> record(cluster,clusterCacheValidity);

--- a/src/SecretCommands.cpp
+++ b/src/SecretCommands.cpp
@@ -391,13 +391,17 @@ std::string deleteSecret(PersistentStore& store, const Secret& secret, bool forc
 				log_info("Forcing deletion of " << secret << " in spite of error");
 		}
 	}
+	if(!store.removeSecret(secret.id)){
+		log_error("Failed to delete " << secret << " from persistent store");
+		return "Failed to delete secret from persistent store";
+	}
 	return "";
 }
 std::string deleteSecretFromStore(PersistentStore& store, const Secret& secret){
 	//remove from the database
 	if(!store.removeSecret(secret.id)){
 		log_error("Failed to delete " << secret << " from persistent store");
-		return "Failed to delete secret from database";
+		return "Failed to delete secret from persistent store";
 	}
 	return "";
 }

--- a/src/SecretCommands.cpp
+++ b/src/SecretCommands.cpp
@@ -399,7 +399,7 @@ std::string deleteSecretFromStore(PersistentStore& store, const Secret& secret){
 		log_error("Failed to delete " << secret << " from persistent store");
 		return "Failed to delete secret from database";
 	}
-	return "";
+	return deleteSecretFromStore(store, secret);
 }
 }
 

--- a/src/SecretCommands.cpp
+++ b/src/SecretCommands.cpp
@@ -399,7 +399,7 @@ std::string deleteSecretFromStore(PersistentStore& store, const Secret& secret){
 		log_error("Failed to delete " << secret << " from persistent store");
 		return "Failed to delete secret from database";
 	}
-	return deleteSecretFromStore(store, secret);
+	return "";
 }
 }
 

--- a/src/VolumeClaimCommands.cpp
+++ b/src/VolumeClaimCommands.cpp
@@ -587,16 +587,22 @@ namespace internal{
 					log_info("Forcing deletion of " << volume << " in spite of error");
 			}
 		}
-
+		if(!store.removePersistentVolumeClaim(volume.id)){
+			log_error("Failed to delete " << volume << " from persistent store");
+			return "Failed to delete volume claim from persistent store";
+		}
+		else{
+			log_info("Successfully removed volume claim from persistent store");
+		}
 	}
 	std::string deleteVolumeClaimFromStore(PersistentStore& store, const PersistentVolumeClaim& volume){
 	// Remove from the database
 		bool success=store.removePersistentVolumeClaim(volume.id);
 		if(!success){
 			log_error("Failed to delete " << volume << " from persistent store");
-			return "Failed to delete volume from database";
+			return "Failed to delete volume claim from persistent store";
 		} else {
-			log_info("Successfully removed Volume Claim from database");
+			log_info("Successfully removed Volume Claim from persistent store");
 		}
 		return "";
 	}

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1299,36 +1299,36 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 		if(ping.status==200){
 			rapidjson::Document json;
 			json.Parse(ping.body.c_str());
-			if(!json.HasMember("reachable") || !json["reachable"].IsBool()){
-				// bool reachable=true;
-				//json["reachable"].GetBool()? reachable=true : reachable=false;
-				//check if the user really wants to perform the deletion
-			}
+			bool reachable=true;
+			json["reachable"].GetBool()? reachable=true : reachable=false;
+			//check if the user really wants to perform the deletion
+			if(reachable){
 			rapidjson::Document resultJSON;
 			resultJSON.Parse(response.body.c_str());
 			std::cout << "Are you sure you want to delete cluster " 
-			<< resultJSON["metadata"]["id"].GetString() << " (" 
-			<< resultJSON["metadata"]["name"].GetString() << ")? "
-			<< "If the cluster still exists, objects may require manual deletion. "
-			<< "Are you sure you want to contine?  [y/n]";
+				<< resultJSON["metadata"]["id"].GetString() << " (" 
+				<< resultJSON["metadata"]["name"].GetString() << ")? "
+				<< "If the cluster still exists, objects may require manual deletion. "
+				<< "Are you sure you want to contine?  [y/n]";
 				std::cout.flush();
 				HideProgress quiet(pman_);
 				std::string cont;
 				std::getline(std::cin,cont);
 				if(cont!="y" && cont!="Y")
 					throw std::runtime_error("Cluster deletion aborted");
-				// else{
-				// 	std::cout << "Are you sure you want to delete cluster "
-				// 	<< resultJSON["metadata"]["id"].GetString() << " (" 
-				// 	<< resultJSON["metadata"]["name"].GetString() << ") belonging to group " 
-				// 	<< resultJSON["metadata"]["owningGroup"].GetString() << "? y/[n]: ";
-				// 		std::cout.flush();
-				// 		HideProgress quiet(pman_);
-				// 		std::string answer;
-				// 		std::getline(std::cin,answer);
-				// 		if(answer!="y" && answer!="Y")
-				// 			throw std::runtime_error("Cluster deletion aborted");
-				// }
+			}
+			// else{
+			// 	std::cout << "Are you sure you want to delete cluster "
+			// 	<< resultJSON["metadata"]["id"].GetString() << " (" 
+			// 	<< resultJSON["metadata"]["name"].GetString() << ") belonging to group " 
+			// 	<< resultJSON["metadata"]["owningGroup"].GetString() << "? y/[n]: ";
+			// 		std::cout.flush();
+			// 		HideProgress quiet(pman_);
+			// 		std::string answer;
+			// 		std::getline(std::cin,answer);
+			// 		if(answer!="y" && answer!="Y")
+			// 			throw std::runtime_error("Cluster deletion aborted");
+			// }
 		}
 		else{
 			std::cerr << "Failed to check cluster connectivity";

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1306,7 +1306,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			rapidjson::Document resultJSON;
 			resultJSON.Parse(response.body.c_str());
 			if(!reachable && opt.force)
-				std::cout << " Cluster is unreachable: Remaining objects may require manual deletion. ";
+				std::cout << " Cluster is unreachable: Remaining objects may require manual deletion. " << endl;
 			std::cout << "Are you sure you want to delete cluster "
 			<< resultJSON["metadata"]["id"].GetString() << " (" 
 			<< resultJSON["metadata"]["name"].GetString() << ") belonging to group " 

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1303,7 +1303,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 				// bool reachable=true;
 				//json["reachable"].GetBool()? reachable=true : reachable=false;
 				//check if the user really wants to perform the deletion
-			}G
+			}
 			rapidjson::Document resultJSON;
 			resultJSON.Parse(response.body.c_str());
 			std::cout << "Are you sure you want to delete cluster " 

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1306,7 +1306,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			rapidjson::Document resultJSON;
 			resultJSON.Parse(response.body.c_str());
 			if(!reachable && opt.force)
-				std::cout << " Cluster is unreachable: Remaining objects may require manual deletion. "
+				std::cout << " Cluster is unreachable: Remaining objects may require manual deletion. ";
 			std::cout << "Are you sure you want to delete cluster "
 			<< resultJSON["metadata"]["id"].GetString() << " (" 
 			<< resultJSON["metadata"]["name"].GetString() << ") belonging to group " 

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1301,13 +1301,9 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			json.Parse(ping.body.c_str());
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool()){
 				if(!json["reachable"].GetBool())
-					rapidjson::Document resultJSON;
-					resultJSON.Parse(response.body.c_str());
 					std::cout << "Cluster is unreachable: " 
 					<< "If the cluster still exists, objects may require manual deletion. "
 					<< "Are you sure you want to contine?  [y/n]";
-					std::cout.flush();
-					HideProgress quiet(pman_);
 					std::string answer;
 					std::getline(std::cin,answer);
 					if(answer!="y" && answer!="Y")

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1300,7 +1300,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			rapidjson::Document json;
 			json.Parse(ping.body.c_str());
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool()){
-				if(json["reachable"].GetBool()==false)
+				if(json["reachable"].GetBool(false))
 					std::cout << "Cluster is unreachable: " 
 					<< "If the cluster still exists, objects may require manual deletion. "
 					<< "Are you sure you want to contine?  [y/n]";

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1294,19 +1294,6 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			showError(response.body);
 			throw std::runtime_error("Cluster deletion aborted");
 		}
-		//check if the user really wants to perform the deletion
-		rapidjson::Document resultJSON;
-		resultJSON.Parse(response.body.c_str());
-		std::cout << "Are you sure you want to delete cluster "
-		<< resultJSON["metadata"]["id"].GetString() << " (" 
-		<< resultJSON["metadata"]["name"].GetString() << ") belonging to group " 
-		<< resultJSON["metadata"]["owningGroup"].GetString() << "? y/[n]: ";
-			std::cout.flush();
-			HideProgress quiet(pman_);
-			std::string answer;
-			std::getline(std::cin,answer);
-			if(answer!="y" && answer!="Y")
-				throw std::runtime_error("Cluster deletion aborted");
 		//check if the cluster is reachable
 		auto ping=httpRequests::httpGet(makeURL("clusters/"+opt.clusterName+"/ping"),defaultOptions());
 		if(ping.status==200){
@@ -1319,6 +1306,19 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 					std::cout << "Cluster is unreachable: " 
 					<< "If the cluster still exists, objects may require manual deletion. "
 					<< "Are you sure you want to contine?  [y/n]";
+					std::cout.flush();
+					HideProgress quiet(pman_);
+					std::string answer;
+					std::getline(std::cin,answer);
+					if(answer!="y" && answer!="Y")
+						throw std::runtime_error("Cluster deletion aborted");
+				//check if the user really wants to perform the deletion
+				rapidjson::Document resultJSON;
+				resultJSON.Parse(response.body.c_str());
+				std::cout << "Are you sure you want to delete cluster "
+				<< resultJSON["metadata"]["id"].GetString() << " (" 
+				<< resultJSON["metadata"]["name"].GetString() << ") belonging to group " 
+				<< resultJSON["metadata"]["owningGroup"].GetString() << "? y/[n]: ";
 					std::cout.flush();
 					HideProgress quiet(pman_);
 					std::string answer;

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1318,18 +1318,18 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 					if(cont!="y" && cont!="Y")
 						throw std::runtime_error("Cluster deletion aborted");
 				}
-				else{
-					std::cout << "Are you sure you want to delete cluster "
-					<< resultJSON["metadata"]["id"].GetString() << " (" 
-					<< resultJSON["metadata"]["name"].GetString() << ") belonging to group " 
-					<< resultJSON["metadata"]["owningGroup"].GetString() << "? y/[n]: ";
-						std::cout.flush();
-						HideProgress quiet(pman_);
-						std::string answer;
-						std::getline(std::cin,answer);
-						if(answer!="y" && answer!="Y")
-							throw std::runtime_error("Cluster deletion aborted");
-				}
+				// else{
+				// 	std::cout << "Are you sure you want to delete cluster "
+				// 	<< resultJSON["metadata"]["id"].GetString() << " (" 
+				// 	<< resultJSON["metadata"]["name"].GetString() << ") belonging to group " 
+				// 	<< resultJSON["metadata"]["owningGroup"].GetString() << "? y/[n]: ";
+				// 		std::cout.flush();
+				// 		HideProgress quiet(pman_);
+				// 		std::string answer;
+				// 		std::getline(std::cin,answer);
+				// 		if(answer!="y" && answer!="Y")
+				// 			throw std::runtime_error("Cluster deletion aborted");
+				// }
 			}
 		}
 		else{

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1300,7 +1300,8 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			rapidjson::Document json;
 			json.Parse(ping.body.c_str());
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool()){
-				if(json["reachable"].GetBool(false))
+				bool reachable;
+				if(json["reachable"].GetBool()? reachable=true : reachable=false)
 					std::cout << "Cluster is unreachable: " 
 					<< "If the cluster still exists, objects may require manual deletion. "
 					<< "Are you sure you want to contine?  [y/n]";

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1300,7 +1300,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			rapidjson::Document json;
 			json.Parse(ping.body.c_str());
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool()){
-				if(!json["reachable"].GetBool())
+				if(json["reachable"].GetBool()==false)
 					std::cout << "Cluster is unreachable: " 
 					<< "If the cluster still exists, objects may require manual deletion. "
 					<< "Are you sure you want to contine?  [y/n]";

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1304,9 +1304,9 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 					std::cout << "Cluster is unreachable: " 
 					<< "If the cluster still exists, objects may require manual deletion. "
 					<< "Are you sure you want to contine?  [y/n]";
-					std::string answer;
-					std::getline(std::cin,answer);
-					if(answer!="y" && answer!="Y")
+					std::string cont;
+					std::getline(std::cin,cont);
+					if(cont!="y" && cont!="Y")
 						throw std::runtime_error("Cluster deletion aborted");
 				//check if the user really wants to perform the deletion
 				rapidjson::Document resultJSON;

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1301,7 +1301,8 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			json.Parse(ping.body.c_str());
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool()){
 				bool reachable;
-				if(json["reachable"].GetBool()? reachable=true : reachable=false)
+				json["reachable"].GetBool()? reachable=true : reachable=false;
+				if(!reachable){
 					std::cout << "Cluster is unreachable: " 
 					<< "If the cluster still exists, objects may require manual deletion. "
 					<< "Are you sure you want to contine?  [y/n]";
@@ -1309,6 +1310,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 					std::getline(std::cin,cont);
 					if(cont!="y" && cont!="Y")
 						throw std::runtime_error("Cluster deletion aborted");
+				}
 				//check if the user really wants to perform the deletion
 				rapidjson::Document resultJSON;
 				resultJSON.Parse(response.body.c_str());

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1294,7 +1294,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			rapidjson::Document json;
 			json.Parse(response.body.c_str());
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool())
-				bool reachable=false
+				reachable=false
 		}
 	}
 	//check that the user really wants to force delete an unreachable cluster

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1295,9 +1295,11 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			json.Parse(response.body.c_str());
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool())
 				bool reachable=false
+		}
+	}
+	//check that the user really wants to force delete an unreachable cluster
 	if(!reachable && opt.force){
 		if(!opt.assumeYes){
-			//check that the user really wants to do the deletion
 			auto url=makeURL("clusters/"+opt.clusterName);
 			auto response=httpRequests::httpGet(url,defaultOptions());
 			if(response.status!=200){
@@ -1319,8 +1321,8 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 					throw std::runtime_error("Cluster deletion aborted");
 		}
 	}
+	//check that the user really wants to do the deletion
 	if(!opt.assumeYes){ 
-		//check that the user really wants to do the deletion
 		auto url=makeURL("clusters/"+opt.clusterName);
 		auto response=httpRequests::httpGet(url,defaultOptions());
 		if(response.status!=200){

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1294,7 +1294,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			rapidjson::Document json;
 			json.Parse(ping.body.c_str());
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool())
-				bool reachable;
+				bool reachable = true;
 				json["reachable"].GetBool() ? reachable=true : bool reachable=false;
 		}
 		else{

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1314,6 +1314,8 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			json.Parse(ping.body.c_str());
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool()){
 				if(!json["reachable"].GetBool())
+					rapidjson::Document resultJSON;
+					resultJSON.Parse(response.body.c_str());
 					std::cout << "Cluster is unreachable: " 
 					<< "If the cluster still exists, objects may require manual deletion. "
 					<< "Are you sure you want to contine?  [y/n]";

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1306,7 +1306,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			rapidjson::Document resultJSON;
 			resultJSON.Parse(response.body.c_str());
 			if(!reachable && opt.force)
-				std::cout << " Cluster is unreachable: Remaining objects may require manual deletion. " << endl;
+				std::cout << " Cluster is unreachable: Remaining objects may require manual deletion. " << std::endl;
 			std::cout << "Are you sure you want to delete cluster "
 			<< resultJSON["metadata"]["id"].GetString() << " (" 
 			<< resultJSON["metadata"]["name"].GetString() << ") belonging to group " 

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1301,29 +1301,35 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			json.Parse(ping.body.c_str());
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool()){
 				bool reachable=true;
-				json["reachable"].GetBool()? reachable=true : reachable=false;
+				//json["reachable"].GetBool()? reachable=true : reachable=false;
+				//check if the user really wants to perform the deletion
+				rapidjson::Document resultJSON;
+				resultJSON.Parse(response.body.c_str());
 				if(reachable){
-					std::cout << "Cluster is unreachable: " 
+					std::cout << "Are you sure you want to delete cluster " 
+					<< resultJSON["metadata"]["id"].GetString() << " (" 
+					<< resultJSON["metadata"]["name"].GetString() << ")? "
 					<< "If the cluster still exists, objects may require manual deletion. "
 					<< "Are you sure you want to contine?  [y/n]";
+					std::cout.flush();
+					HideProgress quiet(pman_);
 					std::string cont;
 					std::getline(std::cin,cont);
 					if(cont!="y" && cont!="Y")
 						throw std::runtime_error("Cluster deletion aborted");
 				}
-				//check if the user really wants to perform the deletion
-				rapidjson::Document resultJSON;
-				resultJSON.Parse(response.body.c_str());
-				std::cout << "Are you sure you want to delete cluster "
-				<< resultJSON["metadata"]["id"].GetString() << " (" 
-				<< resultJSON["metadata"]["name"].GetString() << ") belonging to group " 
-				<< resultJSON["metadata"]["owningGroup"].GetString() << "? y/[n]: ";
-					std::cout.flush();
-					HideProgress quiet(pman_);
-					std::string answer;
-					std::getline(std::cin,answer);
-					if(answer!="y" && answer!="Y")
-						throw std::runtime_error("Cluster deletion aborted");
+				else{
+					std::cout << "Are you sure you want to delete cluster "
+					<< resultJSON["metadata"]["id"].GetString() << " (" 
+					<< resultJSON["metadata"]["name"].GetString() << ") belonging to group " 
+					<< resultJSON["metadata"]["owningGroup"].GetString() << "? y/[n]: ";
+						std::cout.flush();
+						HideProgress quiet(pman_);
+						std::string answer;
+						std::getline(std::cin,answer);
+						if(answer!="y" && answer!="Y")
+							throw std::runtime_error("Cluster deletion aborted");
+				}
 			}
 		}
 		else{

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1300,9 +1300,9 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			rapidjson::Document json;
 			json.Parse(ping.body.c_str());
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool()){
-				bool reachable;
+				bool reachable=true;
 				json["reachable"].GetBool()? reachable=true : reachable=false;
-				if(!reachable){
+				if(reachable){
 					std::cout << "Cluster is unreachable: " 
 					<< "If the cluster still exists, objects may require manual deletion. "
 					<< "Are you sure you want to contine?  [y/n]";

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1300,23 +1300,22 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			rapidjson::Document json;
 			json.Parse(ping.body.c_str());
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool()){
-				bool reachable=true;
+				// bool reachable=true;
 				//json["reachable"].GetBool()? reachable=true : reachable=false;
 				//check if the user really wants to perform the deletion
 				rapidjson::Document resultJSON;
 				resultJSON.Parse(response.body.c_str());
-				if(reachable){
-					std::cout << "Are you sure you want to delete cluster " 
-					<< resultJSON["metadata"]["id"].GetString() << " (" 
-					<< resultJSON["metadata"]["name"].GetString() << ")? "
-					<< "If the cluster still exists, objects may require manual deletion. "
-					<< "Are you sure you want to contine?  [y/n]";
-					std::cout.flush();
-					HideProgress quiet(pman_);
-					std::string cont;
-					std::getline(std::cin,cont);
-					if(cont!="y" && cont!="Y")
-						throw std::runtime_error("Cluster deletion aborted");
+				std::cout << "Are you sure you want to delete cluster " 
+				<< resultJSON["metadata"]["id"].GetString() << " (" 
+				<< resultJSON["metadata"]["name"].GetString() << ")? "
+				<< "If the cluster still exists, objects may require manual deletion. "
+				<< "Are you sure you want to contine?  [y/n]";
+				std::cout.flush();
+				HideProgress quiet(pman_);
+				std::string cont;
+				std::getline(std::cin,cont);
+				if(cont!="y" && cont!="Y")
+					throw std::runtime_error("Cluster deletion aborted");
 				}
 				// else{
 				// 	std::cout << "Are you sure you want to delete cluster "

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1295,7 +1295,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			throw std::runtime_error("Cluster deletion aborted");
 		}
 		//check if cluster is reachable
-		reachable=true;
+		bool reachable=true;
 		auto response=httpRequests::httpGet(makeURL("clusters/"+opt.clusterName+"/ping"),defaultOptions());
 		if(this->clientShouldPrintOnlyJson())
 			std::cout << response.body << std::endl;

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1294,7 +1294,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			rapidjson::Document json;
 			json.Parse(response.body.c_str());
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool())
-				reachable=false
+				reachable=false;
 		}
 	}
 	//check that the user really wants to force delete an unreachable cluster

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1303,20 +1303,20 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 				// bool reachable=true;
 				//json["reachable"].GetBool()? reachable=true : reachable=false;
 				//check if the user really wants to perform the deletion
-				rapidjson::Document resultJSON;
-				resultJSON.Parse(response.body.c_str());
-				std::cout << "Are you sure you want to delete cluster " 
-				<< resultJSON["metadata"]["id"].GetString() << " (" 
-				<< resultJSON["metadata"]["name"].GetString() << ")? "
-				<< "If the cluster still exists, objects may require manual deletion. "
-				<< "Are you sure you want to contine?  [y/n]";
-					std::cout.flush();
-					HideProgress quiet(pman_);
-					std::string cont;
-					std::getline(std::cin,cont);
-					if(cont!="y" && cont!="Y")
-						throw std::runtime_error("Cluster deletion aborted");
-				}
+			}G
+			rapidjson::Document resultJSON;
+			resultJSON.Parse(response.body.c_str());
+			std::cout << "Are you sure you want to delete cluster " 
+			<< resultJSON["metadata"]["id"].GetString() << " (" 
+			<< resultJSON["metadata"]["name"].GetString() << ")? "
+			<< "If the cluster still exists, objects may require manual deletion. "
+			<< "Are you sure you want to contine?  [y/n]";
+				std::cout.flush();
+				HideProgress quiet(pman_);
+				std::string cont;
+				std::getline(std::cin,cont);
+				if(cont!="y" && cont!="Y")
+					throw std::runtime_error("Cluster deletion aborted");
 				// else{
 				// 	std::cout << "Are you sure you want to delete cluster "
 				// 	<< resultJSON["metadata"]["id"].GetString() << " (" 

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1286,7 +1286,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 	ProgressToken progress(pman_,"Deleting cluster...");
 
 	//check if cluster is reachable
-	reachable=true;
+	std::bool reachable=true;
 	auto response=httpRequests::httpGet(makeURL("clusters/"+opt.clusterName+"/ping"),defaultOptions());
 	if(this->clientShouldPrintOnlyJson())
 		std::cout << response.body << std::endl;

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1295,7 +1295,8 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 				rapidjson::Document json;
 				json.Parse(ping.body.c_str());
 				if(!json.HasMember("reachable") || !json["reachable"].IsBool())
-					json["reachable"].GetBool() ? bool reachable=true : bool reachable=false;
+					bool reachable;
+					json["reachable"].GetBool() ? reachable=true : bool reachable=false;
 			}
 			else{
 				std::cerr << "Failed check cluster connectivity";

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1285,25 +1285,25 @@ void Client::updateCluster(const ClusterUpdateOptions& opt){
 void Client::deleteCluster(const ClusterDeleteOptions& opt){
 	ProgressToken progress(pman_,"Deleting cluster...");
 
-	if(!opt.assumeYes){
-		//check if cluster is reachable
-		auto ping=httpRequests::httpGet(makeURL("clusters/"+opt.clusterName+"/ping"),defaultOptions());
-		if(this->clientShouldPrintOnlyJson())
-			std::cout << ping.body << std::endl;
-		else{
-			if(ping.status==200){
-				rapidjson::Document json;
-				json.Parse(ping.body.c_str());
-				if(!json.HasMember("reachable") || !json["reachable"].IsBool())
-					bool reachable;
-					json["reachable"].GetBool() ? reachable=true : bool reachable=false;
-			}
-			else{
-				std::cerr << "Failed check cluster connectivity";
-				showError(ping.body);
-				throw OperationFailed();
-			}
+	//check if cluster is reachable
+	auto ping=httpRequests::httpGet(makeURL("clusters/"+opt.clusterName+"/ping"),defaultOptions());
+	if(this->clientShouldPrintOnlyJson())
+		std::cout << ping.body << std::endl;
+	else{
+		if(ping.status==200){
+			rapidjson::Document json;
+			json.Parse(ping.body.c_str());
+			if(!json.HasMember("reachable") || !json["reachable"].IsBool())
+				bool reachable;
+				json["reachable"].GetBool() ? reachable=true : bool reachable=false;
 		}
+		else{
+			std::cerr << "Failed check cluster connectivity";
+			showError(ping.body);
+			throw OperationFailed();
+		}
+	}
+	if(!opt.assumeYes){
 		//check if the cluster exists 
 		auto url=makeURL("clusters/"+opt.clusterName);
 		auto response=httpRequests::httpGet(url,defaultOptions());

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1318,7 +1318,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 					<< "If the cluster still exists, objects may require manual deletion. "
 					<< "Are you sure you want to contine?  [y/n]";
 					std::cout.flush();
-G					HideProgress quiet(pman_);
+					HideProgress quiet(pman_);
 					std::string answer;
 					std::getline(std::cin,answer);
 					if(answer!="y" && answer!="Y")

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1329,7 +1329,6 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 				// 		if(answer!="y" && answer!="Y")
 				// 			throw std::runtime_error("Cluster deletion aborted");
 				// }
-			}
 		}
 		else{
 			std::cerr << "Failed to check cluster connectivity";

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1287,7 +1287,6 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 
 	if(!opt.assumeYes){
 		//check if cluster is reachable
-		bool reachable=true;
 		auto ping=httpRequests::httpGet(makeURL("clusters/"+opt.clusterName+"/ping"),defaultOptions());
 		if(this->clientShouldPrintOnlyJson())
 			std::cout << ping.body << std::endl;
@@ -1296,7 +1295,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 				rapidjson::Document json;
 				json.Parse(ping.body.c_str());
 				if(!json.HasMember("reachable") || !json["reachable"].IsBool())
-					json["reachable"].GetBool() ? reachable=true : reachable=false;
+					json["reachable"].GetBool() ? bool reachable=true : bool reachable=false;
 			}
 			else{
 				std::cerr << "Failed check cluster connectivity";

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1285,15 +1285,7 @@ void Client::updateCluster(const ClusterUpdateOptions& opt){
 void Client::deleteCluster(const ClusterDeleteOptions& opt){
 	ProgressToken progress(pman_,"Deleting cluster...");
 
-	//check if the cluster exists
-	if(!opt.assumeYes){ 
-		auto url=makeURL("clusters/"+opt.clusterName);
-		auto response=httpRequests::httpGet(url,defaultOptions());
-		if(response.status!=200){
-			std::cerr << "Failed to get cluster " << opt.clusterName;
-			showError(response.body);
-			throw std::runtime_error("Cluster deletion aborted");
-		}
+	if(!opt.assumeYes){
 		//check if cluster is reachable
 		bool reachable=true;
 		auto ping=httpRequests::httpGet(makeURL("clusters/"+opt.clusterName+"/ping"),defaultOptions());
@@ -1311,6 +1303,14 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 				showError(ping.body);
 				throw OperationFailed();
 			}
+		}
+		//check if the cluster exists 
+		auto url=makeURL("clusters/"+opt.clusterName);
+		auto response=httpRequests::httpGet(url,defaultOptions());
+		if(response.status!=200){
+			std::cerr << "Failed to get cluster " << opt.clusterName;
+			showError(response.body);
+			throw std::runtime_error("Cluster deletion aborted");
 		}
 		//check if the user really wants to perform the deletion
 		if(reachable){

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1294,7 +1294,6 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			showError(response.body);
 			throw std::runtime_error("Cluster deletion aborted");
 		}
-		//check if the user really wants to perform the deletion
 		auto ping=httpRequests::httpGet(makeURL("clusters/"+opt.clusterName+"/ping"),defaultOptions());
 		if(ping.status==200){
 			//check if the cluster is reachable
@@ -1302,7 +1301,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			pingResultJSON.Parse(ping.body.c_str());
 			bool reachable;
 			pingResultJSON["reachable"].GetBool()? reachable=true : reachable=false;
-			//perform deletion check
+			//check if the user really wants to perform the deletion
 			rapidjson::Document resultJSON;
 			resultJSON.Parse(response.body.c_str());
 			if(!reachable && opt.force)

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1287,7 +1287,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 
 	if(!opt.assumeYes){
 		//check if cluster is reachable
-		bool reachable=true;
+		bool reachable
 		auto ping=httpRequests::httpGet(makeURL("clusters/"+opt.clusterName+"/ping"),defaultOptions());
 		if(this->clientShouldPrintOnlyJson())
 			std::cout << ping.body << std::endl;
@@ -1296,7 +1296,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 				rapidjson::Document json;
 				json.Parse(ping.body.c_str());
 				if(!json.HasMember("reachable") || !json["reachable"].IsBool())
-					reachable=false;
+					json["reachable"].GetBool() ? reachable=true : reachable=false;
 			}
 			else{
 				std::cerr << "Failed check cluster connectivity";

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1287,7 +1287,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 
 	if(!opt.assumeYes){
 		//check if cluster is reachable
-		bool reachable
+		bool reachable=true;
 		auto ping=httpRequests::httpGet(makeURL("clusters/"+opt.clusterName+"/ping"),defaultOptions());
 		if(this->clientShouldPrintOnlyJson())
 			std::cout << ping.body << std::endl;

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1295,7 +1295,7 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 			json.Parse(ping.body.c_str());
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool())
 				bool reachable = true;
-				json["reachable"].GetBool() ? reachable=true : bool reachable=false;
+				json["reachable"].GetBool() ? reachable=true : reachable=false;
 		}
 		else{
 			std::cerr << "Failed check cluster connectivity";

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1310,12 +1310,12 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 				<< resultJSON["metadata"]["name"].GetString() << ")? "
 				<< "If the cluster still exists, objects may require manual deletion. "
 				<< "Are you sure you want to contine?  [y/n]";
-				std::cout.flush();
-				HideProgress quiet(pman_);
-				std::string cont;
-				std::getline(std::cin,cont);
-				if(cont!="y" && cont!="Y")
-					throw std::runtime_error("Cluster deletion aborted");
+					std::cout.flush();
+					HideProgress quiet(pman_);
+					std::string cont;
+					std::getline(std::cin,cont);
+					if(cont!="y" && cont!="Y")
+						throw std::runtime_error("Cluster deletion aborted");
 				}
 				// else{
 				// 	std::cout << "Are you sure you want to delete cluster "

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1293,8 +1293,8 @@ void Client::deleteCluster(const ClusterDeleteOptions& opt){
 		if(ping.status==200){
 			rapidjson::Document json;
 			json.Parse(ping.body.c_str());
+			bool reachable = true;
 			if(!json.HasMember("reachable") || !json["reachable"].IsBool())
-				bool reachable = true;
 				json["reachable"].GetBool() ? reachable=true : reachable=false;
 		}
 		else{

--- a/test/TODO.md
+++ b/test/TODO.md
@@ -1,0 +1,105 @@
+# Issue #140: Skip Cascading Deletion
+
+Adds an option to force delete an unreachable cluster. This will skip the standard method of cascading deletion in which objects on the backend are deleted in succession. Since the cluster is unreachable, now a message will appear stating that the cluster cannot be contacted. Once a `--force` flag is provided a different message will prompt the user if they want to skip object deletion and simply remove database entries. If a `-y` flag is provided or the user answers `yes`, then the slate-client-server will delete the database entries and move on.
+
+A new test was written to ensure that this feature continues to work, but some issues were noted with the new test in a pull-request to close issue #140. In order to make a cluster unreachable, the `clusterCacheValidity` in `persistentStore.cpp` time must be set to a shorter period than the default 30 minutes. This time is added to a `std::chrono::steady_clock::now()`  method and this defines the `clusterCacheExpirationTime` which will force slate to check the database when searching for a clusters stored kubeconfig.
+
+The test written is designed to update the cluster with an invalid kubeconfig, set clusterCacheValidity to 1 second, and then run a `slate cluster delete --force [CLUSTER_ID]` to ensure that cascading deletion is skipped and the cluster records are then deleted. Following this, a database entry check is performed to ensure that the entries were successfully deleted.
+
+Unfortunately, to set the clusterCacheValidity time to 1 second using an `add cluster` command with a new option defined in `clusterCommands.cpp` called `setCacheValidity` is a bad idea, and users should not be able to arbitrarily change the global cache settings. Chris Weaver left some comments on this issue and how to change the clusterCacheValidity time using the CLI configuration code. Below are some notes he left in a previous pull-request.
+
+## Comments
+
+Allowing any user to change the server's caching period when  adding a cluster is very bad and must be removed. The correct way to to  approach this is to 1) update [the CLI configurtion code](https://github.com/slateci/slate-client-server/blob/skipCascadingDeletion/src/slate_service.cpp#L110) to support setting the cache validity period(s) with options, 2) set those on the `PersistentStore` after it is constructed, and 3) change the test to set the new option(s) on the server that it starts via the `TestContext`, using the support it [already has for setting options](https://github.com/slateci/slate-client-server/blob/skipCascadingDeletion/test/test.h#L147).
+
+The breakage of all of the other API object's user-facing deletion functions is also a blocking issue and must be resolved.
+
+```c++
+// COMMENT 1
+include/PersistentStore.h
+@@ -282,7 +288,7 @@ class PersistentStore{
+282	///Store a record for a new cluster
+283	///\param cluster the new cluster
+284	///\return Whether the record was successfully added to the database
+285 -	bool addCluster(const Cluster& cluster);
+291	+   bool addCluster(const Cluster& cluster, int cacheExpirationTime = 0);
+Member
+@cnweaver cnweaver 4 days ago
+
+//I don't think that setting the cache validity time should be a part of this function's interface. If you want to change the validity period used when considering cluster records going forward, setClusterCacheValidity should just be called before calling addCluster.
+
+```
+
+```c++
+// COMMENT 2
+src/ClusterCommands.cpp
+411 -		log_error("Failed to create " << cluster);
+412 -		return crow::response(500,generateError("Cluster registration failed"));
+409 +
+410 +	if(body["metadata"].HasMember("setCacheValidity")){ //optional configuration for cluster cache validity time
+Member
+@cnweaver cnweaver 4 days ago
+
+//This emphatically should not be exposed this way in the API. Users should not be able to arbitrarily change the global cache settings.
+```
+
+```c++
+// COMMENT 3
+src/PersistentStore.cpp
+@@ -1928,7 +1933,7 @@ SharedFileHandle PersistentStore::configPathForCluster(const std::string& cID){
+	return clusterConfigs.find(cID);
+}
+
+1931 - bool PersistentStore::addCluster(const Cluster& cluster){
+1936 + bool PersistentStore::addCluster(const Cluster& cluster, int cacheExpirationTime){
+Member
+@cnweaver cnweaver 4 days ago
+
+//As noted above, this feature should not be implemented here.
+```
+
+```c++
+// COMMENT 4
+test/TestClusterDeletion.cpp
+340 +		metadata.AddMember("group", rapidjson::StringRef(groupID), alloc);
+341 +		metadata.AddMember("owningOrganization", "Department of Labor", alloc);
+342 +		metadata.AddMember("kubeconfig", rapidjson::StringRef(kubeConfig), alloc);
+343 +		metadata.AddMember("setClusterCacheValidity", 1, alloc);
+Member
+@cnweaver cnweaver 4 days ago
+
+//This is not the right way to handle setting this.
+```
+
+### Note
+
+While other concerns were easily fixed, the comments above allude to a security concern in which a user can arbitrarily set the `clusterCacheValidityTime` and, as a result, the `clusterCacheExpirationTime` as well.
+
+This means a user could potentially overload the database by setting the `clusterCacheValidity` time to a very short interval on the SLATE production API server. Since caching is used for accessing most of our data, it would be very expensive if the database was being queried for every data request. While the option is hidden to most users, a saboteur could find this option in the API server and run an HTTP request to add a new cluster and alter the `clusterCacheValidity`.
+
+To get around this issue, Chris recommended that the option be set in the CLI configuration code in the `slate_service.cpp` file. Then the option could be called in the `TestContext` options.
+
+Some issues were initially encountered when attempting this before. First is that in the `slate_service.cpp` file it seems that you cannot set a configuration option for the data type of `std::chrono::[time_interval]` such as `std::chrono::seconds`, and thus you can't directly set the configuration option to the correct data type for `clusterCacheValidity` time.
+
+Next it was noted that the `TestContext` will need public access to the new configuration option in order to change the persistent store configuration on startup.
+
+In addition to this, somehow this new value for `clusterCacheValidity` needs to overwrite the default time of 30 minutes (1800 seconds). Potentially this could be done using the already existing method of `setClusterCacheValidity()` in `persistentStore.cpp`. Strangely enough, however, this method only seemed to work properly when it was run as part of the `addCluster()` in the persistent store.
+
+If `setClusterCacheValidity()` was called by itself <u>in the test</u> then a get method `getClusterCacheValidity()` would return the new cache validity of 1 second, as expected. But when that same get method was called as part of a method in the `persistetntStore.cpp`, it would return the default 1800 seconds. 
+
+This was a source of much confusion; it could be it has something to do with the `TestContext`, or a problem with calling persistent store methods directly in a test. HTTP requests seem to work just fine, but that is where we ran into our security issue as described above.
+
+### Suggestion
+
+First create a new configuration option in `slate_service.cpp` to set a desired integer in seconds.
+
+ Then find a way to pass that integer to the persistent store configuration and replace the default value at `persistentstore.cpp Line #231` from `std::chrono::minutes(30)` to `std::chrono::seconds(foo)` after the persistent store is constructed. 
+
+Then ensure that the `TestContext` has access to that configuration option and set it to a short time interval like 1 second. 
+
+If everything is successful, when running `ctest -V -R test-cluster-deletion`  the test called `ForceDeletingUnreachableCluster` should pass and report that the cluster components cannot be reached.
+
+**Cleanup**
+
+After all that, be sure to clean up old changes made to `crow::response createCluster()` method in `ClusterCommands.cpp`, changes made to the `addCluster()` method in `PersistentStore.cpp`, and the option added to the `create cluster HTTP request` in the `ForceDeletingUnreachableCluster` test.
+

--- a/test/TestClusterDeletion.cpp
+++ b/test/TestClusterDeletion.cpp
@@ -400,7 +400,8 @@ TEST(ForceDeletingUnreachableCluster){
 
 	// make cluster unreachable
 	std::system("echo $KUBECONFIG >> /tmp/kubeconfig.txt && KUBECONFIG=blank");
-	clusterID="blank";
+	auto clusterID="blank";
+	std::cout << clusterID
 
 	// delete cluster records and skip cascading deletion
 	auto deleteResp=httpDelete(tc.getAPIServerURL()+"/"+currentAPIVersion+"/clusters/"+clusterID+

--- a/test/TestClusterDeletion.cpp
+++ b/test/TestClusterDeletion.cpp
@@ -7,7 +7,7 @@
 #include <KubeInterface.h>
 #include <Entities.h>
 #include <iostream>
-
+/* 
 TEST(UnauthenticatedDeleteCluster){
 	using namespace httpRequests;
 	TestContext tc;
@@ -297,7 +297,7 @@ TEST(DeletingClusterHasCascadingDeletion){
 	stopReaper();
 	ENSURE_EQUAL(names.output.find("slate-group-testgroup1"), std::string::npos, "Cluster deletion should delete associated namespaces");
 }
-
+ */
 TEST(ForceDeletingUnreachableCluster){
 	// Make a, VO, cluster, instance, and secrets
 	// Then verify the latter were deleted as a consequence of deleting the cluster
@@ -400,6 +400,7 @@ TEST(ForceDeletingUnreachableCluster){
 
 	// make cluster unreachable
 	std::system("echo $KUBECONFIG >> /tmp/kubeconfig.txt && KUBECONFIG=blank");
+	clusterID="blank"
 
 	// delete cluster records and skip cascading deletion
 	auto deleteResp=httpDelete(tc.getAPIServerURL()+"/"+currentAPIVersion+"/clusters/"+clusterID+
@@ -417,9 +418,10 @@ TEST(ForceDeletingUnreachableCluster){
 	auto secret = store.getSecret(secretID);
 	ENSURE_EQUAL(instance, ApplicationInstance(), "Cluster deletion should delete instances");
 	ENSURE_EQUAL(secret, Secret(), "Cluster deletion should delete secrets");
-	
+/* 	
 	// perform full deletion
 	ENSURE_EQUAL(deleteResp.status,200,"Cluster deletion should succeed");
+	auto clusterID=createData["metadata"]["id"].GetString();
 
 	// Get kubeconfig, save it to file, and use it to check namespaces
 	std::string conf = tc.getKubeConfig();
@@ -432,5 +434,5 @@ TEST(ForceDeletingUnreachableCluster){
 	kubernetes::kubectl("./testconfigdeletion.yaml", argDelete);
 	auto names = kubernetes::kubectl("./testconfigdeletion.yaml", args);
 	stopReaper();
-	ENSURE_EQUAL(names.output.find("slate-group-testgroup1"), std::string::npos, "Cluster deletion should delete associated namespaces");
+	ENSURE_EQUAL(names.output.find("slate-group-testgroup1"), std::string::npos, "Cluster deletion should delete associated namespaces"); */
 }

--- a/test/TestClusterDeletion.cpp
+++ b/test/TestClusterDeletion.cpp
@@ -340,7 +340,7 @@ TEST(ForceDeletingUnreachableCluster){
 		metadata.AddMember("group", rapidjson::StringRef(groupID), alloc);
 		metadata.AddMember("owningOrganization", "Department of Labor", alloc);
 		metadata.AddMember("kubeconfig", rapidjson::StringRef(kubeConfig), alloc);
-		metadata.AddMember("setCacheValidity", 1, alloc);
+		metadata.AddMember("setClusterCacheValidity", 1, alloc);
 		request1.AddMember("metadata", metadata, alloc);
 	}
 	auto createResp=httpPost(createClusterUrl, to_string(request1));

--- a/test/TestClusterDeletion.cpp
+++ b/test/TestClusterDeletion.cpp
@@ -7,7 +7,7 @@
 #include <KubeInterface.h>
 #include <Entities.h>
 #include <iostream>
-/*
+
 TEST(UnauthenticatedDeleteCluster){
 	using namespace httpRequests;
 	TestContext tc;
@@ -297,7 +297,7 @@ TEST(DeletingClusterHasCascadingDeletion){
 	stopReaper();
 	ENSURE_EQUAL(names.output.find("slate-group-testgroup1"), std::string::npos, "Cluster deletion should delete associated namespaces");
 }
-*/
+
 TEST(ForceDeletingUnreachableCluster){
 	// Make a, VO, cluster, instance, and secrets
 	// Then verify the latter were deleted as a consequence of deleting the cluster

--- a/test/TestClusterDeletion.cpp
+++ b/test/TestClusterDeletion.cpp
@@ -400,7 +400,7 @@ TEST(ForceDeletingUnreachableCluster){
 
 	// make cluster unreachable
 	std::system("echo $KUBECONFIG >> /tmp/kubeconfig.txt && KUBECONFIG=blank");
-	clusterID="blank"
+	clusterID="blank";
 
 	// delete cluster records and skip cascading deletion
 	auto deleteResp=httpDelete(tc.getAPIServerURL()+"/"+currentAPIVersion+"/clusters/"+clusterID+

--- a/test/TestClusterDeletion.cpp
+++ b/test/TestClusterDeletion.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 #include <ClusterCommands.h>
 
-/* TEST(UnauthenticatedDeleteCluster){
+TEST(UnauthenticatedDeleteCluster){
 	using namespace httpRequests;
 	TestContext tc;
 	
@@ -298,7 +298,7 @@ TEST(DeletingClusterHasCascadingDeletion){
 	stopReaper();
 	ENSURE_EQUAL(names.output.find("slate-group-testgroup1"), std::string::npos, "Cluster deletion should delete associated namespaces");
 }
- */
+
 TEST(ForceDeletingUnreachableCluster){
 	// Make a, VO, cluster, instance, and secrets
 	// Then verify the latter were deleted as a consequence of deleting the cluster

--- a/test/TestClusterDeletion.cpp
+++ b/test/TestClusterDeletion.cpp
@@ -7,7 +7,7 @@
 #include <KubeInterface.h>
 #include <Entities.h>
 #include <iostream>
-/* 
+
 TEST(UnauthenticatedDeleteCluster){
 	using namespace httpRequests;
 	TestContext tc;
@@ -297,7 +297,7 @@ TEST(DeletingClusterHasCascadingDeletion){
 	stopReaper();
 	ENSURE_EQUAL(names.output.find("slate-group-testgroup1"), std::string::npos, "Cluster deletion should delete associated namespaces");
 }
-*/
+
 TEST(ForceDeletingUnreachableCluster){
 	// Make a, VO, cluster, instance, and secrets
 	// Then verify the latter were deleted as a consequence of deleting the cluster

--- a/test/TestClusterDeletion.cpp
+++ b/test/TestClusterDeletion.cpp
@@ -401,7 +401,7 @@ TEST(ForceDeletingUnreachableCluster){
 	// make cluster unreachable
 	std::system("echo $KUBECONFIG >> /tmp/kubeconfig.txt && KUBECONFIG=blank");
 	auto clusterID="blank";
-	std::cout << clusterID
+	std::cout << clusterID;
 
 	// delete cluster records and skip cascading deletion
 	auto deleteResp=httpDelete(tc.getAPIServerURL()+"/"+currentAPIVersion+"/clusters/"+clusterID+

--- a/test/test.h
+++ b/test/test.h
@@ -148,7 +148,6 @@ public:
 	~TestContext();
 	std::string getAPIServerURL() const;
 	std::string getKubeConfig();
-	std::string getDummyKubeConfig();
 	///Get the user record for the web-portal user
 	const User& getPortalUser() const{ return db.getPortalUser(); }
 	///Fetch the web-portal user's user ID

--- a/test/test.h
+++ b/test/test.h
@@ -148,6 +148,7 @@ public:
 	~TestContext();
 	std::string getAPIServerURL() const;
 	std::string getKubeConfig();
+	std::string getDummyKubeConfig();
 	///Get the user record for the web-portal user
 	const User& getPortalUser() const{ return db.getPortalUser(); }
 	///Fetch the web-portal user's user ID

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -3,7 +3,6 @@
 #include <iostream>
 #include <thread>
 #include <stdexcept>
-#include <string>
 
 #include <unistd.h>
 #include <signal.h>
@@ -269,7 +268,6 @@ std::string TestContext::getKubeConfig(){
 		{
 			std::ofstream configStream(configFile);
 			configStream << kubeconfig;
-			configStream.close();
 		}
 		startReaper();
 		auto result=runCommand("kubectl",

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -286,34 +286,6 @@ std::string TestContext::getKubeConfig(){
 	return kubeconfig;
 }
 
-std::string TestContext::getDummyKubeConfig(){
-
-	FileHandle configFile=makeTemporaryFile(".tmp_config_");
-	{
-		std::ofstream configStream(configFile);
-		configStream << "apiVersion: v1" << std::endl << "clusters:" << std::endl << "- cluster:" << std::endl
-		  << "    certificate-authority-data:" << std::endl << "    server: invalid" << std::endl
-		  << "  name: invalid" << std::endl << "contexts:" << std::endl << "- context:" << std::endl
-		  << "    cluster: invalid" << std::endl << "    namespace: test-0" << std::endl << "    user: test-0" << std::endl
-		  << "  name: invalid" << std::endl << "current-context: cluster" << std::endl << "kind: Config" << std::endl
-		  << "preferences: {}" << std::endl << "users:" << std::endl << "- name: test-0" << std::endl 
-		  << "  user:" << std::endl << "    token:" << std::endl;
-		configStream.close();
-	}
-	startReaper();
-	auto result=runCommand("kubectl",
-		{"--kubeconfig="+configFile.path(),"get","serviceaccounts","-o=jsonpath={.items[*].metadata.name}"});
-	stopReaper();
-	std::string account;
-	std::istringstream accounts(result.output);
-	while(accounts >> account){
-		if(account!="default")
-			break;
-	}
-	namespaceName=account;
-	return kubeconfig;
-}
-
 std::string getPortalUserID(){
 	std::string uid;
 	std::string line;


### PR DESCRIPTION
Closes #140 

When attempting to delete an unreachable cluster slate may fail to delete it or wait a long time for timeouts to run on object deletion. 

With this change, if a cluster cannot be reached then it will notify the user and '--force' must be provided to delete the cluster records. This will speed up deletion and ensure that the records can always be deleted if standard deletion fails. If the cluster still exists then objects may remain on the backend which must be manually deleted. 

Also adds a test to check if an unreachable cluster can have its record deleted. The test will attempt to shut down the kubelet or minikube depending on the environment, run a --force delete, then restarts kubelet/minikube and does full deletion.

Fixes a bug in which deletion tests will always pass even if the components are unreachable.