### PR TITLE
Quote namespace name before passing it to kubectl in cluster registration

### DIFF
--- a/src/client/ClusterRegistration.cpp
+++ b/src/client/ClusterRegistration.cpp
@@ -359,7 +359,7 @@ Client::ClusterConfig Client::extractClusterConfig(std::string configPath, bool 
 R"(apiVersion: nrp-nautilus.io/v1alpha1
 kind: Cluster
 metadata: 
-  name: )" << namespaceName << std::endl;
+  name: )" << "'" << namespaceName << "'" << std::endl;
 		result=runCommand("kubectl",{"create","-f",clusterFile});
 		if(result.status)
 			throw std::runtime_error("Cluster creation failed: "+result.error);


### PR DESCRIPTION
Fixed issue 166: The client crashes with an error on passing 'y' as a namespace name. This was because yaml tried to interpret y (without quotes) as a bool.

Quoting the namespace name while writing it out to the yaml fixes it.