### PR TITLE
Kubectl namespace validate

### DIFF
--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -20,8 +20,6 @@
 #include "rapidjson/stringbuffer.h"
 #include "HTTPRequests.h"
 
-#define LABEL_NAME_MAX_LEN 255
-
 #if ! ( __APPLE__ && __MACH__ )
 	//Whether to use CURLOPT_CAINFO to specifiy a CA bundle path.
 	//According to https://curl.haxx.se/libcurl/c/CURLOPT_CAINFO.html

--- a/include/client/Client.h
+++ b/include/client/Client.h
@@ -20,6 +20,8 @@
 #include "rapidjson/stringbuffer.h"
 #include "HTTPRequests.h"
 
+#define LABEL_NAME_MAX_LEN 255
+
 #if ! ( __APPLE__ && __MACH__ )
 	//Whether to use CURLOPT_CAINFO to specifiy a CA bundle path.
 	//According to https://curl.haxx.se/libcurl/c/CURLOPT_CAINFO.html
@@ -608,6 +610,8 @@ private:
 	static bool verifySecretID(const std::string& id);
 	///return true if the argument matches the corret format for the volume ID
 	static bool verifyVolumeID(const std::string& id);	
+	///return true if the argument matches the correct format for a namespace name
+	static bool verifyNamespaceName(const std::string& id);
 
 	mutable std::string endpointPath;
 	mutable std::string apiEndpoint;

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -3621,3 +3621,17 @@ bool Client::verifyVolumeID(const std::string& id){
 		return false;
 	return true;
 }
+
+bool Client::verifyNamespaceName(const std::string& namespaceName){
+	if (namespaceName.length() <= LABEL_NAME_MAX_LEN){
+		if (std::iswalnum(namespaceName.front()) && std::iswalnum(namespaceName.back())) {
+			for (auto itr = std::next(namespaceName.begin()); itr != std::prev(namespaceName.end()); ++itr) {
+				if (!(std::iswalnum(*itr) || *itr == '-')) {
+					return false;
+				}
+			}
+			return true;
+		}
+	}
+	return false;
+}

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -3623,15 +3623,20 @@ bool Client::verifyVolumeID(const std::string& id){
 }
 
 bool Client::verifyNamespaceName(const std::string& namespaceName){
-	if (namespaceName.length() <= LABEL_NAME_MAX_LEN){
-		if (std::iswalnum(namespaceName.front()) && std::iswalnum(namespaceName.back())) {
+	const unsigned int MaxLabelNameLen = 255;
+	if (namespaceName.length() > MaxLabelNameLen || namespaceName.empty())
+		return false;
+	else if(std::iswalnum(namespaceName.front()) && std::iswalnum(namespaceName.back())){
+		if(namespaceName.length() == 1)
+			return true;
+		else{
 			for (auto itr = std::next(namespaceName.begin()); itr != std::prev(namespaceName.end()); ++itr) {
-				if (!(std::iswalnum(*itr) || *itr == '-')) {
+				if (!(std::iswalnum(*itr) || *itr == '-'))
 					return false;
-				}
 			}
 			return true;
 		}
 	}
-	return false;
+	else
+		return false;
 }

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -3626,17 +3626,17 @@ bool Client::verifyNamespaceName(const std::string& namespaceName){
 	const unsigned int MaxLabelNameLen = 255;
 	if (namespaceName.length() > MaxLabelNameLen || namespaceName.empty())
 		return false;
-	else if(std::iswalnum(namespaceName.front()) && std::iswalnum(namespaceName.back())){
+	
+	if(std::iswalnum(namespaceName.front()) && std::iswalnum(namespaceName.back())){
 		if(namespaceName.length() == 1)
 			return true;
-		else{
-			for (auto itr = std::next(namespaceName.begin()); itr != std::prev(namespaceName.end()); ++itr) {
-				if (!(std::iswalnum(*itr) || *itr == '-'))
-					return false;
-			}
-			return true;
+		
+		for (auto itr = std::next(namespaceName.begin()); itr != std::prev(namespaceName.end()); ++itr) {
+			if (!(std::iswalnum(*itr) || *itr == '-'))
+				return false;
 		}
+		return true;
 	}
-	else
-		return false;
+	
+	return false;
 }

--- a/src/client/ClusterRegistration.cpp
+++ b/src/client/ClusterRegistration.cpp
@@ -334,6 +334,13 @@ Client::ClusterConfig Client::extractClusterConfig(std::string configPath, bool 
 	
 	if(namespaceName.empty())
 		namespaceName=defaultSystemNamespace;
+
+	// check whether namespace name follows RFC 1123 (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
+	if(namespaceName != defaultSystemNamespace){
+		if(! verifyNamespaceName(namespaceName))
+			throw std::runtime_error("Invalid namespace name - Namespace names must follow RFC 1123 specification.");
+	} 
+
 	//check whether the selected namespace/cluster already exists
 	auto result=runCommand("kubectl",{"get","cluster",namespaceName,"-o","name"});
 	if(result.status==0 && result.output.find("cluster.nrp-nautilus.io/"+namespaceName)!=std::string::npos){


### PR DESCRIPTION
Namespace names must follow RFC 1123 to count as a valid kubernetes namespace.

See [#170](https://github.com/slateci/slate-client-server/issues/170) for a detailed explanation.