### PR TITLE
Add script for feature146

### DIFF
--- a/resources/external_scripts/getresource.sh
+++ b/resources/external_scripts/getresource.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Fetch all nodes and their names only
+NODES=$(kubectl get nodes | tail -n +2 | cut -d' ' -f1)
+
+# Read each node name
+while IFS= read -r line; do
+	echo "Node: $line"
+
+	# Call kubectl describe on each node and grep for CPU and Memory, last 2 lines only
+	RESOURCE_STATS=$(kubectl describe node "$line" | grep 'cpu \| memory' | tail -n2)
+	
+	# Read each line from RESOUCE_STATS
+	while read line; do
+		# Get CPU and Memory  requests inside the parentheses
+		echo "$line" | cut -d'(' -f2 | cut -d')' -f1
+	done <<< "$RESOURCE_STATS"
+done <<< "$NODES"


### PR DESCRIPTION
Add a script `getresource.sh` that prints out CPU and Memory usage on a per node basis. Feature #146 needs this script to be installed on PATH so that it can be called from the server code.

```
[adityavi@node1 external_scripts]$ ./getresource.sh
Node: node1.av-testnode.slate-pg0.wisc.cloudlab.us
2%
0%
Node: node1.av-workernode.slate-pg0.wisc.cloudlab.us
0%
0%
```

First line is CPU, the 2nd line is memory usage.