### PR TITLE
Client update: Update install urls to the correct version (#265)

### DIFF
--- a/src/client/ClusterRegistration.cpp
+++ b/src/client/ClusterRegistration.cpp
@@ -18,8 +18,8 @@ void Client::ensureFederationController(const std::string &configPath, bool assu
 	// New controller deployment URL - hosted on GitHub with source code
 	// const static std::string controllerDeploymentURL="https://raw.githubusercontent.com/slateci/slate-client-server/master/resources/federation-deployment.yaml";
 	// yaml for new controller
-	const static std::string controllerDeploymentURL = "https://raw.githubusercontent.com/slateci/federation-controller/rename_and_upgrade_support/resources/installation/upgrade-controller-debug.yaml";
-	const static std::string federationRoleURL = "https://raw.githubusercontent.com/slateci/federation-controller/rename_and_upgrade_support/resources/installation/federation-role.yaml";
+	const static std::string controllerDeploymentURL = "https://raw.githubusercontent.com/slateci/federation-controller/main/resources/installation/upgrade-controller-debug.yaml";
+	const static std::string federationRoleURL = "https://raw.githubusercontent.com/slateci/federation-controller/main/resources/installation/federation-role.yaml";
 
 	std::cout << "Checking federation-controller status..." << std::endl;
 	auto result = runCommand("kubectl", {"get", "deployments", "-n", "kube-system", "--kubeconfig", configPath});


### PR DESCRIPTION
Not pushing a new API server version as this is just a client update. Merging onto *master* for tagging and release.