### PR TITLE
Add support for using ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,18 @@
 cmake_minimum_required (VERSION 3.0.0 FATAL_ERROR)
 cmake_policy(VERSION 3.0.0)
+project(Slate)
 
 SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_C_STANDARD 11)
+
+# setup ccache if using
+include(cmake/Packages/UseCompilerCache.cmake)
+if(NOT SLATE_DISABLE_COMPILER_CACHE)
+  useCompilerCache()
+endif()
+
+# setup options
+option(SLATE_DISABLE_COMPILER_CACHE "Disables compiler cache." OFF)
 
 # -----------------------------------------------------------------------------
 # Set up installation

--- a/cmake/Packages/UseCompilerCache.cmake
+++ b/cmake/Packages/UseCompilerCache.cmake
@@ -1,0 +1,33 @@
+# Enable ccache compiler cache
+function(useCompilerCache)
+    if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+        return()
+    endif()
+    find_program(CCACHE_EXECUTABLE ccache)
+    if(NOT CCACHE_EXECUTABLE)
+        return()
+    endif()
+    # Use a cache variable so the user can override this
+    set(CCACHE_ENV CCACHE_SLOPPINESS=pch_defines,time_macros
+            CACHE STRING
+            "List of environment variables for ccache, each in key=value form"
+            )
+    if(CMAKE_GENERATOR MATCHES "Ninja|Makefiles")
+        message("Using compiler cache")
+        foreach(lang IN ITEMS C CXX)
+            set(CMAKE_${lang}_COMPILER_LAUNCHER
+                    ${CMAKE_COMMAND} -E env ${CCACHE_ENV} ${CCACHE_EXECUTABLE}
+                    PARENT_SCOPE
+                    )
+        endforeach()
+    endif()
+
+    message(STATUS "Using ccache (${CCACHE_EXECUTABLE}).")
+
+    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(CMAKE_DISABLE_PRECOMPILE_HEADERS ON CACHE BOOL "" FORCE)
+        message(STATUS "Precompiled headers disabled because of non-Debug "
+                "build with ccache."
+                )
+    endif()
+endfunction()

--- a/resources/docker/clion_remote.Dockerfile
+++ b/resources/docker/clion_remote.Dockerfile
@@ -12,10 +12,7 @@
 #   user@password
 
 
-#FROM centos:7
-# FROM hub.opensciencegrid.org/slate/slate-client-server:1.0.7
 ARG baseimage=hub.opensciencegrid.org/slate/slate-client-server:2.0.4
-#ARG baseimage=localhost/slate-rocky:1
 ARG port=18080
 FROM ${baseimage} as local-stage
 
@@ -48,12 +45,6 @@ ARG versionoverride="X.Y.Z"
 
 # Docker container environmental variables:
 ENV VERSION_OVERRIDE=${versionoverride}
-
-# Set up custom yum repos:
-# COPY ./yum.repos.d/aws-sdk.repo /etc/yum.repos.d/aws-sdk.repo
-
-# Package installs/updates:
-#RUN yum install epel-release -y
 
 RUN dnf -y update \
  && dnf -y install openssh-server \
@@ -100,6 +91,7 @@ RUN dnf -y update \
   perf \
   valgrind \
   valgrind-devel \
+  ccache \
   && dnf clean all
 
 # Install AWS CLI

--- a/resources/docker/clion_remote.Dockerfile
+++ b/resources/docker/clion_remote.Dockerfile
@@ -12,7 +12,7 @@
 #   user@password
 
 
-ARG baseimage=hub.opensciencegrid.org/slate/slate-client-server:2.0.4
+ARG baseimage=hub.opensciencegrid.org/slate/slate-client-server:2.1.0
 ARG port=18080
 FROM ${baseimage} as local-stage
 
@@ -91,7 +91,6 @@ RUN dnf -y update \
   perf \
   valgrind \
   valgrind-devel \
-  ccache \
   && dnf clean all
 
 # Install AWS CLI


### PR DESCRIPTION
This should dramatically speed up builds of the slate binaries.  The container needs to have ccache installed and we just need to set `CCACHE_DIR` to something like `/tmp/slate-cache` .  Then untar a prepopulated cache dir before building and we'll avoid the need to build most of the slate code.  We'll probably need have 3 artifacts (one for each container type) and need to update them every so often (e.g. every 1-3 version releases).  There's a way to serve this using a [http server](https://ccache.dev/manual/4.5.1.html#_http_storage_backend) but using tarballs is probably easier right now.