### PR TITLE
Opentel additions

### DIFF
--- a/include/Telemetry.h
+++ b/include/Telemetry.h
@@ -23,6 +23,9 @@ namespace trace     = opentelemetry::trace;
 namespace nostd     = opentelemetry::nostd;
 namespace resource = opentelemetry::sdk::resource;
 
+// how many traces to sample and send
+const double samplingRatio = 0.5;
+
 ///Initialize opentelemetry tracing for application
 ///\param endpoint url to opentelemetry server endpoint
 ///\param resources settings used to initalize opentelemetry tracing
@@ -32,6 +35,26 @@ void initializeTracer(const std::string& endpoint, const resource::ResourceAttri
 ///\param tracerName name for tracer to retrieve
 ///\return A shared ptr to a tracer that can be used to generate spans
 nostd::shared_ptr<trace::Tracer> getTracer(const std::string& tracerName = "SlateAPIServer");
+
+///Get options to use when creating a span for web facing functions
+///\param req crow request
+///\return Options to use to create a web span
+trace::StartSpanOptions getWebSpanOptions(const crow::request& req);
+
+///Get attributes to use when creating a span for internal functions
+///\param spanAttributes map with attributes
+///\return Attributes to use to create a web span
+void setInternalSpanAttributes(std::map<std::string, std::string>& spanAttributes);
+
+///Get options to use when creating a span for internal functions
+///\return Options to use to create a web span
+trace::StartSpanOptions getInternalSpanOptions();
+
+///Get attributes to use when creating a span for web facing functions
+///\param spanAttributes map with attributes
+///\param req crow request
+///\return Attributes to use to create a web span
+void setWebSpanAttributes(std::map<std::string, std::string>& spanAttributes, const crow::request& req);
 
 ///Set attributes for a span based on a crow request
 ///\param span span to populate with attributes
@@ -49,5 +72,6 @@ void setWebSpanError(nostd::shared_ptr<trace::Span>& span, const std::string& me
 ///\param mesg error message to add to span
 ///\param errorCode http error code for span
 void setSpanError(nostd::shared_ptr<trace::Span>& span, const std::string& mesg);
+
 
 #endif //SLATE_CLIENT_SERVER_TELEMETRY_H

--- a/src/ApplicationCommands.cpp
+++ b/src/ApplicationCommands.cpp
@@ -61,7 +61,10 @@ std::string filterValuesFile(std::string data){
 
 crow::response listApplications(PersistentStore& store, const crow::request& req){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 
@@ -117,7 +120,10 @@ crow::response listApplications(PersistentStore& store, const crow::request& req
 
 crow::response fetchApplicationConfig(PersistentStore& store, const crow::request& req, const std::string& appName){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 
@@ -183,7 +189,11 @@ crow::response fetchApplicationConfig(PersistentStore& store, const crow::reques
 
 crow::response fetchApplicationVersions(PersistentStore& store, const crow::request& req, const std::string& appName){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
+;
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 
@@ -263,7 +273,11 @@ crow::response fetchApplicationVersions(PersistentStore& store, const crow::requ
 
 crow::response fetchApplicationDocumentation(PersistentStore& store, const crow::request& req, const std::string& appName){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
+;
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	const User user=authenticateUser(store, req.url_params.get("token"));
@@ -353,7 +367,10 @@ std::string assembleExtraHelmValues(const PersistentStore& store, const Cluster&
 ///Internal function which requires that initial authorization checks have already been performed
 crow::response installApplicationImpl(PersistentStore& store, const User& user, const std::string& appName, const std::string& installSrc, const rapidjson::Document& body){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan("installApplicationImpl");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("installApplicationImpl", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 	span->SetAttribute("user", user.name);
 
@@ -585,7 +602,9 @@ crow::response installApplicationImpl(PersistentStore& store, const User& user, 
 	auto clusterConfig=store.configPathForCluster(cluster.id);
 
 	span->AddEvent("kubectl create ns");
-	auto nsSpan = tracer->StartSpan("kubectl create ns");
+	setInternalSpanAttributes(attributes);
+	options = getInternalSpanOptions();
+	auto nsSpan = tracer->StartSpan("kubectl create ns", attributes, options);
 	auto nsScope = tracer->WithActiveSpan(nsSpan);
 	try{
 		kubernetes::kubectl_create_namespace(*clusterConfig, group);
@@ -618,7 +637,9 @@ crow::response installApplicationImpl(PersistentStore& store, const User& user, 
 	}
 
 	span->AddEvent("helm install");
-	auto helmSpan = tracer->StartSpan("helm install");
+	setInternalSpanAttributes(attributes);
+	options = getInternalSpanOptions();
+	auto helmSpan = tracer->StartSpan("helm install", attributes, options);
 	auto helmScope = tracer->WithActiveSpan(helmSpan);
 	auto commandResult=runCommand("helm",installArgs,{{"KUBECONFIG",*clusterConfig}});
 	//if application instantiation fails, remove record from DB again
@@ -644,7 +665,9 @@ crow::response installApplicationImpl(PersistentStore& store, const User& user, 
 		}
 
 		span->AddEvent("helm cleanup delete");
-		auto helmDeleteSpan = tracer->StartSpan("helm cleanup delete");
+		setInternalSpanAttributes(attributes);
+		options = getInternalSpanOptions();
+		auto helmDeleteSpan = tracer->StartSpan("helm cleanup delete", attributes, options);
 		auto helmDeleteScope = tracer->WithActiveSpan(helmDeleteSpan);
 		runCommand("helm",deleteArgs,{{"KUBECONFIG",*clusterConfig}});
 		helmDeleteSpan->End();
@@ -700,7 +723,11 @@ crow::response installApplicationImpl(PersistentStore& store, const User& user, 
 
 crow::response installApplication(PersistentStore& store, const crow::request& req, const std::string& appName){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
+;
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -765,7 +792,10 @@ crow::response installApplication(PersistentStore& store, const crow::request& r
 //or false and the error message from helm
 std::pair<bool,std::string> extractChartName(const std::string& path){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan("extractChartName");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("extractChartName", attributes, options);
 
 	span->AddEvent("helm inspect chart");
 	auto result=kubernetes::helm("","",{"inspect","chart",path});
@@ -791,7 +821,11 @@ std::pair<bool,std::string> extractChartName(const std::string& path){
 
 crow::response installAdHocApplication(PersistentStore& store, const crow::request& req){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
+;
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -919,7 +953,11 @@ crow::response installAdHocApplication(PersistentStore& store, const crow::reque
 
 crow::response updateCatalog(PersistentStore& store, const crow::request& req){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
+;
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate

--- a/src/ApplicationInstanceCommands.cpp
+++ b/src/ApplicationInstanceCommands.cpp
@@ -13,7 +13,10 @@
 
 crow::response listApplicationInstances(PersistentStore& store, const crow::request& req){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 
@@ -120,7 +123,11 @@ std::multimap<std::string,ServiceInterface> getServices(const SharedFileHandle& 
                                                    const std::string& nspace,
                                                    const std::string& systemNamespace){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan("getServices");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("getServices", attributes, options);
+
 	auto scope = tracer->WithActiveSpan(span);
 
 	using namespace std::chrono;
@@ -377,7 +384,10 @@ rapidjson::Value fetchInstanceDetails(PersistentStore& store,
                                       const std::string& systemNamespace, 
                                       rapidjson::Document::AllocatorType& alloc){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan("fetchInstanceDetails");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("fetchInstanceDetails", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	rapidjson::Value instanceDetails(rapidjson::kObjectType);
@@ -533,7 +543,10 @@ rapidjson::Value fetchInstanceDetails(PersistentStore& store,
 
 crow::response fetchApplicationInstanceInfo(PersistentStore& store, const crow::request& req, const std::string& instanceID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -662,7 +675,10 @@ crow::response fetchApplicationInstanceInfo(PersistentStore& store, const crow::
 
 crow::response deleteApplicationInstance(PersistentStore& store, const crow::request& req, const std::string& instanceID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -711,7 +727,10 @@ crow::response deleteApplicationInstance(PersistentStore& store, const crow::req
 namespace internal{
 std::string deleteApplicationInstance(PersistentStore& store, const ApplicationInstance& instance, bool force){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan("deleteApplicationInstance");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("deleteApplicationInstance", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	log_info("Deleting " << instance);
@@ -766,7 +785,10 @@ std::string deleteApplicationInstance(PersistentStore& store, const ApplicationI
 
 crow::response updateApplicationInstance(PersistentStore& store, const crow::request& req, const std::string& instanceID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -1015,7 +1037,9 @@ crow::response updateApplicationInstance(PersistentStore& store, const crow::req
 
 	commandResult commandResult;
 	{
-		auto helmSpan = tracer->StartSpan("helm install");
+		setInternalSpanAttributes(attributes);
+		options = getInternalSpanOptions();
+		auto helmSpan = tracer->StartSpan("helm install", attributes, options);
 		populateSpan(helmSpan, req);
 		auto helmScope = tracer->WithActiveSpan(helmSpan);
 		commandResult = runCommand("helm", installArgs, {{"KUBECONFIG", *clusterConfig}});
@@ -1079,7 +1103,10 @@ crow::response updateApplicationInstance(PersistentStore& store, const crow::req
 
 crow::response restartApplicationInstance(PersistentStore& store, const crow::request& req, const std::string& instanceID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -1314,7 +1341,10 @@ crow::response restartApplicationInstance(PersistentStore& store, const crow::re
 
 crow::response getApplicationInstanceScale(PersistentStore& store, const crow::request& req, const std::string& instanceID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -1421,7 +1451,10 @@ crow::response getApplicationInstanceScale(PersistentStore& store, const crow::r
 
 crow::response scaleApplicationInstance(PersistentStore& store, const crow::request& req, const std::string& instanceID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -1575,7 +1608,10 @@ crow::response getApplicationInstanceLogs(PersistentStore& store,
                                           const crow::request& req, 
                                           const std::string& instanceID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate

--- a/src/ClusterCommands.cpp
+++ b/src/ClusterCommands.cpp
@@ -32,7 +32,10 @@ crow::response listClusters(PersistentStore& store, const crow::request& req){
 	std::vector<Cluster> clusters;
 
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -118,7 +121,10 @@ namespace internal {
 	///\return any informative message for the user
 	std::string setClusterDNSRecord(PersistentStore &store, const Cluster &cluster) {
 		auto tracer = getTracer();
-		auto span = tracer->StartSpan("setClusterDNSRecord");
+		std::map<std::string, std::string> attributes;
+		setInternalSpanAttributes(attributes);
+		auto options = getInternalSpanOptions();
+		auto span = tracer->StartSpan("setClusterDNSRecord", attributes, options);
 		auto scope = tracer->WithActiveSpan(span);
 
 		std::string resultMessage;
@@ -182,7 +188,10 @@ namespace internal {
 	///\throw std::runtime_error
 	std::string ensureClusterSetup(PersistentStore &store, const Cluster &cluster) {
 		auto tracer = getTracer();
-		auto span = tracer->StartSpan("ensureClusterSetup");
+		std::map<std::string, std::string> attributes;
+		setInternalSpanAttributes(attributes);
+		auto options = getInternalSpanOptions();
+		auto span = tracer->StartSpan("ensureClusterSetup", attributes, options);
 		auto scope = tracer->WithActiveSpan(span);
 
 		auto configPath = store.configPathForCluster(cluster.id);
@@ -408,7 +417,10 @@ namespace internal {
 
 crow::response createCluster(PersistentStore& store, const crow::request& req) {
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -828,7 +840,10 @@ crow::response getClusterInfo(PersistentStore& store, const crow::request& req,
                               const std::string clusterID) {
 	auto provider = opentelemetry::trace::Provider::GetTracerProvider();
 	auto tracer = provider->GetTracer("SlateAPIServer", serverVersionString);
-	auto span = tracer->StartSpan("getClusterInfo");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("getClusterInfo", attributes, options);
 	const User user=authenticateUser(store, req.url_params.get("token"));
 	log_info(user << " requested information about " << clusterID << " from " << req.remote_endpoint);
 	if(!user) {
@@ -990,7 +1005,10 @@ crow::response getClusterInfo(PersistentStore& store, const crow::request& req,
 crow::response deleteCluster(PersistentStore& store, const crow::request& req, 
                              const std::string& clusterID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -1190,7 +1208,10 @@ std::string deleteCluster(PersistentStore& store, const Cluster& cluster, bool f
 crow::response updateCluster(PersistentStore& store, const crow::request& req, 
                              const std::string& clusterID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -1356,7 +1377,10 @@ crow::response updateCluster(PersistentStore& store, const crow::request& req,
 crow::response listClusterAllowedgroups(PersistentStore& store, const crow::request& req, 
                                      const std::string& clusterID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -1435,7 +1459,10 @@ crow::response listClusterAllowedgroups(PersistentStore& store, const crow::requ
 crow::response checkGroupClusterAccess(PersistentStore& store, const crow::request& req, 
 									   const std::string& clusterID, const std::string& groupID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -1500,7 +1527,10 @@ crow::response checkGroupClusterAccess(PersistentStore& store, const crow::reque
 crow::response grantGroupClusterAccess(PersistentStore& store, const crow::request& req, 
                                     const std::string& clusterID, const std::string& groupID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -1577,7 +1607,10 @@ crow::response grantGroupClusterAccess(PersistentStore& store, const crow::reque
 crow::response revokeGroupClusterAccess(PersistentStore& store, const crow::request& req, 
                                      const std::string& clusterID, const std::string& groupID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -1658,7 +1691,10 @@ crow::response listClusterGroupAllowedApplications(PersistentStore& store,
 												const std::string& groupID){
 
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -1722,7 +1758,10 @@ crow::response allowGroupUseOfApplication(PersistentStore& store, const crow::re
                                        const std::string& clusterID, const std::string& groupID,
                                        const std::string& applicationName){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -1787,7 +1826,10 @@ crow::response denyGroupUseOfApplication(PersistentStore& store, const crow::req
                                       const std::string& clusterID, const std::string& groupID,
                                       const std::string& applicationName) {
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -1853,7 +1895,10 @@ crow::response getClusterMonitoringCredential(PersistentStore& store,
                                               const crow::request& req,
                                               const std::string& clusterID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -1972,7 +2017,10 @@ crow::response removeClusterMonitoringCredential(PersistentStore& store,
                                                  const crow::request& req,
                                                  const std::string& clusterID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -2227,7 +2275,10 @@ rapidjson::Document ClusterConsistencyResult::toJSON() const{
 crow::response pingCluster(PersistentStore& store, const crow::request& req,
                            const std::string& clusterID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -2281,7 +2332,10 @@ crow::response pingCluster(PersistentStore& store, const crow::request& req,
 crow::response verifyCluster(PersistentStore& store, const crow::request& req,
                              const std::string& clusterID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -2313,7 +2367,10 @@ crow::response verifyCluster(PersistentStore& store, const crow::request& req,
 crow::response repairCluster(PersistentStore& store, const crow::request& req,
                              const std::string& clusterID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate

--- a/src/GroupCommands.cpp
+++ b/src/GroupCommands.cpp
@@ -103,7 +103,10 @@ crow::response listGroups(PersistentStore& store, const crow::request& req){
 	using namespace std::chrono;
 	high_resolution_clock::time_point t1 = high_resolution_clock::now();
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -158,7 +161,10 @@ crow::response listGroups(PersistentStore& store, const crow::request& req){
 
 crow::response createGroup(PersistentStore& store, const crow::request& req){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -369,7 +375,10 @@ crow::response createGroup(PersistentStore& store, const crow::request& req){
 
 crow::response getGroupInfo(PersistentStore& store, const crow::request& req, const std::string& groupID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -415,7 +424,10 @@ crow::response getGroupInfo(PersistentStore& store, const crow::request& req, co
 
 crow::response updateGroup(PersistentStore& store, const crow::request& req, const std::string& groupID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -548,7 +560,10 @@ crow::response updateGroup(PersistentStore& store, const crow::request& req, con
 
 crow::response deleteGroup(PersistentStore& store, const crow::request& req, const std::string& groupID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -640,7 +655,10 @@ crow::response deleteGroup(PersistentStore& store, const crow::request& req, con
 
 crow::response listGroupMembers(PersistentStore& store, const crow::request& req, const std::string& groupID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -702,7 +720,10 @@ crow::response listGroupMembers(PersistentStore& store, const crow::request& req
 
 crow::response listGroupClusters(PersistentStore& store, const crow::request& req, const std::string& groupID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate

--- a/src/KubeInterface.cpp
+++ b/src/KubeInterface.cpp
@@ -17,7 +17,10 @@ commandResult kubectl(const std::string& configPath,
                       const std::vector<std::string>& arguments){
 #ifdef SLATE_SERVER
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan("kubectl");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("kubectl", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 #endif
 	std::vector<std::string> fullArgs;
@@ -44,7 +47,10 @@ commandResult kubectl(const std::string& configPath,
 int getControllerVersion(const std::string& clusterConfig) {
 #ifdef SLATE_SERVER
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan("getControllerVersion");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("getControllerVersion", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 #endif
     auto result=runCommand("kubectl",{"--kubeconfig",clusterConfig,"get", "crd", "clusternss.slateci.io"});
@@ -120,7 +126,10 @@ commandResult helm(const std::string& configPath,
 
 #ifdef SLATE_SERVER
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan("helm");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("helm", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 #endif
 
@@ -150,7 +159,10 @@ commandResult helm(const std::string& configPath,
 unsigned int getHelmMajorVersion(){
 #ifdef SLATE_SERVER
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan("getHelmMajorVersion");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("getHelmMajorVersion", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 	span->SetAttribute("log.message", "helm version");
 #endif
@@ -200,7 +212,10 @@ std::multimap<std::string,std::string> findAll(const std::string& clusterConfig,
 											   const std::string& nspace, const std::string& verbs){
 #ifdef SLATE_SERVER
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan("findAll");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("findAll", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 #endif
 

--- a/src/MonitoringCredentialCommands.cpp
+++ b/src/MonitoringCredentialCommands.cpp
@@ -8,7 +8,10 @@
 
 crow::response listMonitoringCredentials(PersistentStore& store, const crow::request& req){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -52,7 +55,10 @@ crow::response listMonitoringCredentials(PersistentStore& store, const crow::req
 
 crow::response addMonitoringCredential(PersistentStore& store, const crow::request& req){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -166,7 +172,10 @@ crow::response addMonitoringCredential(PersistentStore& store, const crow::reque
 crow::response revokeMonitoringCredential(PersistentStore& store, const crow::request& req,
                                           const std::string& credentialID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -222,7 +231,10 @@ crow::response revokeMonitoringCredential(PersistentStore& store, const crow::re
 crow::response deleteMonitoringCredential(PersistentStore& store, const crow::request& req,
                                           const std::string& credentialID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate

--- a/src/PersistentStore.cpp
+++ b/src/PersistentStore.cpp
@@ -1040,7 +1040,10 @@ void PersistentStore::loadEncyptionKey(const std::string& fileName){
 
 bool PersistentStore::addUser(const User& user){
 	using Aws::DynamoDB::Model::AttributeValue;
-	auto span = tracer->StartSpan("PersistentStore::addUser");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::addUser", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	auto request=Aws::DynamoDB::Model::PutItemRequest()
@@ -1076,7 +1079,10 @@ bool PersistentStore::addUser(const User& user){
 }
 
 User PersistentStore::getUser(const std::string& id){
-	auto span = tracer->StartSpan("PersistentStore::getUser");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::getUser", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//first see if we have this cached
@@ -1133,7 +1139,10 @@ User PersistentStore::getUser(const std::string& id){
 }
 
 User PersistentStore::findUserByToken(const std::string& token){
-	auto span = tracer->StartSpan("PersistentStore::findUserByToken");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::findUserByToken", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//first see if we have this cached
@@ -1204,7 +1213,10 @@ User PersistentStore::findUserByToken(const std::string& token){
 }
 
 User PersistentStore::findUserByGlobusID(const std::string& globusID){
-	auto span = tracer->StartSpan("PersistentStore::findUserByGlobusID");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::findUserByGlobusID", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//first see if we have this cached
@@ -1271,7 +1283,10 @@ User PersistentStore::findUserByGlobusID(const std::string& globusID){
 }
 
 bool PersistentStore::updateUser(const User& user, const User& oldUser){
-	auto span = tracer->StartSpan("PersistentStore::updateUser");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::updateUser", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	using AV=Aws::DynamoDB::Model::AttributeValue;
@@ -1311,7 +1326,10 @@ bool PersistentStore::updateUser(const User& user, const User& oldUser){
 }
 
 bool PersistentStore::removeUser(const std::string& id){
-	auto span = tracer->StartSpan("PersistentStore::removeUser");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::removeUser", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//erase cache entries
@@ -1351,7 +1369,10 @@ bool PersistentStore::removeUser(const std::string& id){
 }
 
 std::vector<User> PersistentStore::listUsers(){
-	auto span = tracer->StartSpan("PersistentStore::listUsers");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listUsers", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	std::vector<User> collected;
@@ -1417,7 +1438,10 @@ std::vector<User> PersistentStore::listUsers(){
 }
 
 std::vector<User> PersistentStore::listUsersByGroup(const std::string& group){
-	auto span = tracer->StartSpan("PersistentStore::listUsersByGroup");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listUsersByGroup", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//first check if list of users is cached
@@ -1480,7 +1504,10 @@ std::vector<User> PersistentStore::listUsersByGroup(const std::string& group){
 }
 
 bool PersistentStore::addUserToGroup(const std::string& uID, std::string groupID){
-	auto span = tracer->StartSpan("PersistentStore::addUserToGroup");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::addUserToGroup", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//check whether the 'ID' we got was actually a name
@@ -1521,7 +1548,10 @@ bool PersistentStore::addUserToGroup(const std::string& uID, std::string groupID
 }
 
 bool PersistentStore::removeUserFromGroup(const std::string& uID, std::string groupID){
-	auto span = tracer->StartSpan("PersistentStore::removeUserFromGroup");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::removeUserFromGroup", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//check whether the 'ID' we got was actually a name
@@ -1558,7 +1588,10 @@ bool PersistentStore::removeUserFromGroup(const std::string& uID, std::string gr
 }
 
 std::vector<std::string> PersistentStore::getUserGroupMemberships(const std::string& uID, bool useNames){
-	auto span = tracer->StartSpan("PersistentStore::getUserGroupMemberships");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::getUserGroupMemberships", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	using Aws::DynamoDB::Model::AttributeValue;
@@ -1605,7 +1638,10 @@ std::vector<std::string> PersistentStore::getUserGroupMemberships(const std::str
 }
 
 bool PersistentStore::userInGroup(const std::string& uID, std::string groupID){
-	auto span = tracer->StartSpan("PersistentStore::userInGroup");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::userInGroup", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//TODO: possible issue: We only store memberships, so repeated queries about
@@ -1665,7 +1701,10 @@ bool PersistentStore::userInGroup(const std::string& uID, std::string groupID){
 //----
 
 bool PersistentStore::addGroup(const Group& group){
-	auto span = tracer->StartSpan("PersistentStore::addGroup");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::addGroup", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	if(group.email.empty()) {
@@ -1717,7 +1756,10 @@ bool PersistentStore::addGroup(const Group& group){
 }
 
 bool PersistentStore::removeGroup(const std::string& groupID){
-	auto span = tracer->StartSpan("PersistentStore::removeGroup");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::removeGroup", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	using Aws::DynamoDB::Model::AttributeValue;
@@ -1766,7 +1808,10 @@ bool PersistentStore::removeGroup(const std::string& groupID){
 }
 
 bool PersistentStore::updateGroup(const Group& group){
-	auto span = tracer->StartSpan("PersistentStore::updateGroup");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::updateGroup", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	using AV=Aws::DynamoDB::Model::AttributeValue;
@@ -1804,7 +1849,10 @@ bool PersistentStore::updateGroup(const Group& group){
 }
 
 std::vector<std::string> PersistentStore::getMembersOfGroup(const std::string groupID){
-	auto span = tracer->StartSpan("PersistentStore::getMembersOfGroup");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::getMembersOfGroup", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	using Aws::DynamoDB::Model::AttributeValue;
@@ -1835,7 +1883,10 @@ std::vector<std::string> PersistentStore::getMembersOfGroup(const std::string gr
 }
 
 std::vector<std::string> PersistentStore::clustersOwnedByGroup(const std::string groupID){
-	auto span = tracer->StartSpan("PersistentStore::clustersOwnedByGroup");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::clustersOwnedByGroup", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	using Aws::DynamoDB::Model::AttributeValue;
@@ -1866,7 +1917,10 @@ std::vector<std::string> PersistentStore::clustersOwnedByGroup(const std::string
 }
 
 std::vector<Group> PersistentStore::listGroups(){
-	auto span = tracer->StartSpan("PersistentStore::listGroups");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listGroups", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//First check if vos are cached
@@ -1933,7 +1987,10 @@ std::vector<Group> PersistentStore::listGroups(){
 }
 
 std::vector<Group> PersistentStore::listGroupsForUser(const std::string& user){
-	auto span = tracer->StartSpan("PersistentStore::listGroupsForUser");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listGroupsForUser", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	// first check if groups list is cached
@@ -1985,7 +2042,10 @@ std::vector<Group> PersistentStore::listGroupsForUser(const std::string& user){
 }
 
 Group PersistentStore::findGroupByID(const std::string& id){
-	auto span = tracer->StartSpan("PersistentStore::findGroupByID");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::findGroupByID", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//first see if we have this cached
@@ -2039,7 +2099,10 @@ Group PersistentStore::findGroupByID(const std::string& id){
 }
 
 Group PersistentStore::findGroupByName(const std::string& name){
-	auto span = tracer->StartSpan("PersistentStore::findGroupByName");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::findGroupByName", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//first see if we have this cached
@@ -2104,7 +2167,10 @@ Group PersistentStore::findGroupByName(const std::string& name){
 }
 
 Group PersistentStore::getGroup(const std::string& idOrName){
-	auto span = tracer->StartSpan("PersistentStore::getGroup");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::getGroup", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	if(idOrName.find(IDGenerator::groupIDPrefix)==0) {
@@ -2119,7 +2185,10 @@ Group PersistentStore::getGroup(const std::string& idOrName){
 //----
 
 SharedFileHandle PersistentStore::configPathForCluster(const std::string& cID){
-	auto span = tracer->StartSpan("PersistentStore::configPathForCluster");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::configPathForCluster", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	if(!findClusterByID(cID)) { //need to do this to ensure local data is fresh
@@ -2134,7 +2203,10 @@ SharedFileHandle PersistentStore::configPathForCluster(const std::string& cID){
 }
 
 bool PersistentStore::addCluster(const Cluster& cluster){
-	auto span = tracer->StartSpan("PersistentStore::addCluster");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::addCluster", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	using Aws::DynamoDB::Model::AttributeValue;
@@ -2170,7 +2242,10 @@ bool PersistentStore::addCluster(const Cluster& cluster){
 }
 
 void PersistentStore::writeClusterConfigToDisk(const Cluster& cluster){
-	auto span = tracer->StartSpan("PersistentStore::writeClusterConfigToDisk");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::writeClusterConfigToDisk", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	FileHandle file=makeTemporaryFile(clusterConfigDir+"/"+cluster.id+"_v");
@@ -2193,7 +2268,10 @@ void PersistentStore::writeClusterConfigToDisk(const Cluster& cluster){
 }
 
 Cluster PersistentStore::findClusterByID(const std::string& cID){
-	auto span = tracer->StartSpan("PersistentStore::findClusterByID");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::findClusterByID", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//first see if we have this cached
@@ -2250,7 +2328,10 @@ Cluster PersistentStore::findClusterByID(const std::string& cID){
 }
 
 Cluster PersistentStore::findClusterByName(const std::string& name){
-	auto span = tracer->StartSpan("PersistentStore::findClusterByName");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::findClusterByName", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//first see if we have this cached
@@ -2322,7 +2403,10 @@ Cluster PersistentStore::findClusterByName(const std::string& name){
 }
 
 Cluster PersistentStore::getCluster(const std::string& idOrName){
-	auto span = tracer->StartSpan("PersistentStore::getCluster");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::getCluster", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	if(idOrName.find(IDGenerator::clusterIDPrefix)==0) {
@@ -2335,7 +2419,10 @@ Cluster PersistentStore::getCluster(const std::string& idOrName){
 }
 
 bool PersistentStore::removeCluster(const std::string& cID){
-	auto span = tracer->StartSpan("PersistentStore::removeCluster");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::removeCluster", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//remove all records of groups granted access to the cluster
@@ -2392,7 +2479,10 @@ bool PersistentStore::removeCluster(const std::string& cID){
 }
 
 bool PersistentStore::updateCluster(const Cluster& cluster){
-	auto span = tracer->StartSpan("PersistentStore::updateCluster");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::updateCluster", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	using AV=Aws::DynamoDB::Model::AttributeValue;
@@ -2429,7 +2519,10 @@ bool PersistentStore::updateCluster(const Cluster& cluster){
 }
 
 std::vector<Cluster> PersistentStore::listClusters(){
-	auto span = tracer->StartSpan("PersistentStore::listClusters");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listClusters", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	std::vector<Cluster> collected;
@@ -2500,7 +2593,10 @@ std::vector<Cluster> PersistentStore::listClusters(){
 }
 
 std::vector<Cluster> PersistentStore::listClustersByGroup(std::string group){
-	auto span = tracer->StartSpan("PersistentStore::listClustersByGroup");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listClustersByGroup", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	std::vector<Cluster> collected;
@@ -2529,7 +2625,10 @@ std::vector<Cluster> PersistentStore::listClustersByGroup(std::string group){
 }
 
 bool PersistentStore::addGroupToCluster(std::string groupID, std::string cID) {
-	auto span = tracer->StartSpan("PersistentStore::addGroupToCluster");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::addGroupToCluster", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//check whether the Group 'ID' we got was actually a name
@@ -2576,7 +2675,10 @@ bool PersistentStore::addGroupToCluster(std::string groupID, std::string cID) {
 }
 
 bool PersistentStore::removeGroupFromCluster(std::string groupID, std::string cID){
-	auto span = tracer->StartSpan("PersistentStore::removeGroupFromCluster");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::removeGroupFromCluster", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//check whether the Group 'ID' we got was actually a name
@@ -2619,7 +2721,10 @@ bool PersistentStore::removeGroupFromCluster(std::string groupID, std::string cI
 }
 
 std::vector<std::string> PersistentStore::listGroupsAllowedOnCluster(std::string cID, bool useNames){
-	auto span = tracer->StartSpan("PersistentStore::listGroupsAllowedOnCluster");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listGroupsAllowedOnCluster", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//check whether the cluster 'ID' we got was actually a name
@@ -2681,7 +2786,10 @@ std::vector<std::string> PersistentStore::listGroupsAllowedOnCluster(std::string
 }
 
 bool PersistentStore::groupAllowedOnCluster(std::string groupID, std::string cID){
-	auto span = tracer->StartSpan("PersistentStore::groupAllowedOnCluster");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::groupAllowedOnCluster", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//TODO: possible issue: We only store memberships, so repeated queries about
@@ -2767,7 +2875,10 @@ bool PersistentStore::groupAllowedOnCluster(std::string groupID, std::string cID
 }
 
 bool PersistentStore::clusterAllowsAllGroups(std::string cID){
-	auto span = tracer->StartSpan("PersistentStore::clusterAllowsAllGroups");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::clusterAllowsAllGroups", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	{ //check cache first
@@ -2827,7 +2938,10 @@ bool PersistentStore::clusterAllowsAllGroups(std::string cID){
 }
 
 std::set<std::string> PersistentStore::listApplicationsGroupMayUseOnCluster(std::string groupID, std::string cID){
-	auto span = tracer->StartSpan("PersistentStore::listApplicationsGroupMayUseOnCluster");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listApplicationsGroupMayUseOnCluster", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//check whether the Group 'ID' we got was actually a name
@@ -2893,7 +3007,10 @@ std::set<std::string> PersistentStore::listApplicationsGroupMayUseOnCluster(std:
 }
 
 bool PersistentStore::allowVoToUseApplication(std::string groupID, std::string cID, std::string appName){
-	auto span = tracer->StartSpan("PersistentStore::allowVoToUseApplication");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::allowVoToUseApplication", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//check whether the Group 'ID' we got was actually a name
@@ -2955,7 +3072,10 @@ bool PersistentStore::allowVoToUseApplication(std::string groupID, std::string c
 }
 
 bool PersistentStore::denyGroupUseOfApplication(std::string groupID, std::string cID, std::string appName){
-	auto span = tracer->StartSpan("PersistentStore::denyGroupUseOfApplication");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::denyGroupUseOfApplication", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//check whether the Group 'ID' we got was actually a name
@@ -3026,7 +3146,10 @@ bool PersistentStore::denyGroupUseOfApplication(std::string groupID, std::string
 }
 
 bool PersistentStore::groupMayUseApplication(std::string groupID, std::string cID, std::string appName){
-	auto span = tracer->StartSpan("PersistentStore::groupMayUseApplication");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::groupMayUseApplication", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//no need to normalize groupID/cID because listApplicationsGroupMayUseOnCluster will do it
@@ -3041,7 +3164,10 @@ bool PersistentStore::groupMayUseApplication(std::string groupID, std::string cI
 }
 
 std::vector<GeoLocation> PersistentStore::getLocationsForCluster(std::string cID){
-	auto span = tracer->StartSpan("PersistentStore::getLocationsForCluster");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::getLocationsForCluster", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//check whether the cluster 'ID' we got was actually a name
@@ -3104,7 +3230,10 @@ std::vector<GeoLocation> PersistentStore::getLocationsForCluster(std::string cID
 }
 
 bool PersistentStore::setLocationsForCluster(std::string cID, const std::vector<GeoLocation>& locations){
-	auto span = tracer->StartSpan("PersistentStore::setLocationsForCluster");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::setLocationsForCluster", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//check whether the cluster 'ID' we got was actually a name
@@ -3147,7 +3276,10 @@ bool PersistentStore::setLocationsForCluster(std::string cID, const std::vector<
 }
 
 bool PersistentStore::setClusterMonitoringCredential(const std::string& cID, const S3Credential& cred){
-	auto span = tracer->StartSpan("PersistentStore::setClusterMonitoringCredential");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::setClusterMonitoringCredential", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	using AV=Aws::DynamoDB::Model::AttributeValue;
@@ -3180,7 +3312,10 @@ bool PersistentStore::setClusterMonitoringCredential(const std::string& cID, con
 }
 
 bool PersistentStore::removeClusterMonitoringCredential(const std::string& cID){
-	auto span = tracer->StartSpan("PersistentStore::removeClusterMonitoringCredential");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::removeClusterMonitoringCredential", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	using AV=Aws::DynamoDB::Model::AttributeValue;
@@ -3211,7 +3346,10 @@ bool PersistentStore::removeClusterMonitoringCredential(const std::string& cID){
 }
 
 Cluster PersistentStore::findClusterUsingCredential(const S3Credential& cred){
-	auto span = tracer->StartSpan("PersistentStore::findClusterUsingCredential");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::findClusterUsingCredential", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	databaseScans++;
@@ -3260,7 +3398,10 @@ Cluster PersistentStore::findClusterUsingCredential(const S3Credential& cred){
 }
 
 CacheRecord<bool> PersistentStore::getCachedClusterReachability(std::string cID){
-	auto span = tracer->StartSpan("PersistentStore::getCachedClusterReachability");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::getCachedClusterReachability", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//check whether the cluster 'ID' we got was actually a name
@@ -3281,7 +3422,10 @@ CacheRecord<bool> PersistentStore::getCachedClusterReachability(std::string cID)
 }
 
 void PersistentStore::cacheClusterReachability(std::string cID, bool reachable){
-	auto span = tracer->StartSpan("PersistentStore::cacheClusterReachability");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::cacheClusterReachability", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//check whether the cluster 'ID' we got was actually a name
@@ -3299,7 +3443,10 @@ void PersistentStore::cacheClusterReachability(std::string cID, bool reachable){
 }
 
 bool PersistentStore::addApplicationInstance(const ApplicationInstance& inst){
-	auto span = tracer->StartSpan("PersistentStore::addApplicationInstance");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::addApplicationInstance", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	using Aws::DynamoDB::Model::AttributeValue;
@@ -3355,7 +3502,10 @@ bool PersistentStore::addApplicationInstance(const ApplicationInstance& inst){
 }
 
 bool PersistentStore::removeApplicationInstance(const std::string& id){
-	auto span = tracer->StartSpan("PersistentStore::removeApplicationInstance");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::removeApplicationInstance", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//erase cache entries
@@ -3409,7 +3559,10 @@ bool PersistentStore::removeApplicationInstance(const std::string& id){
 }
 
 ApplicationInstance PersistentStore::getApplicationInstance(const std::string& id){
-	auto span = tracer->StartSpan("PersistentStore::getApplicationInstance");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::getApplicationInstance", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//first see if we have this cached
@@ -3466,7 +3619,10 @@ ApplicationInstance PersistentStore::getApplicationInstance(const std::string& i
 }
 
 std::string PersistentStore::getApplicationInstanceConfig(const std::string& id) {
-	auto span = tracer->StartSpan("PersistentStore::getApplicationInstanceConfig");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::getApplicationInstanceConfig", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//first see if we have this cached
@@ -3512,7 +3668,10 @@ std::string PersistentStore::getApplicationInstanceConfig(const std::string& id)
 }
 
 std::vector<ApplicationInstance> PersistentStore::listApplicationInstances(){
-	auto span = tracer->StartSpan("PersistentStore::listApplicationInstances");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listApplicationInstances", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//First check if instances are cached
@@ -3582,7 +3741,10 @@ std::vector<ApplicationInstance> PersistentStore::listApplicationInstances(){
 }
 
 std::vector<ApplicationInstance> PersistentStore::listApplicationInstancesByClusterOrGroup(std::string group, std::string cluster){
-	auto span = tracer->StartSpan("PersistentStore::listApplicationInstancesByClusterOrGroup");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listApplicationInstancesByClusterOrGroup", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	std::vector<ApplicationInstance> instances;
@@ -3686,7 +3848,10 @@ std::vector<ApplicationInstance> PersistentStore::listApplicationInstancesByClus
 }
 
 std::vector<ApplicationInstance> PersistentStore::findInstancesByName(const std::string& name){
-	auto span = tracer->StartSpan("PersistentStore::findInstancesByName");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::findInstancesByName", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//TODO: read from cache
@@ -3770,7 +3935,10 @@ SecretData PersistentStore::decryptSecret(const Secret& s) const{
 }
 
 bool PersistentStore::addSecret(const Secret& secret){
-	auto span = tracer->StartSpan("PersistentStore::addSecret");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::addSecret", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	if(secret.data.substr(0,6)!="scrypt")
@@ -3811,7 +3979,10 @@ bool PersistentStore::addSecret(const Secret& secret){
 }
 
 bool PersistentStore::removeSecret(const std::string& id){
-	auto span = tracer->StartSpan("PersistentStore::removeSecret");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::removeSecret", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//erase cache entries
@@ -3852,7 +4023,10 @@ bool PersistentStore::removeSecret(const std::string& id){
 }
 
 Secret PersistentStore::getSecret(const std::string& id){
-	auto span = tracer->StartSpan("PersistentStore::getSecret");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::getSecret", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//first see if we have this cached
@@ -3907,7 +4081,10 @@ Secret PersistentStore::getSecret(const std::string& id){
 }
 
 std::vector<Secret> PersistentStore::listSecrets(std::string group, std::string cluster){
-	auto span = tracer->StartSpan("PersistentStore::listSecrets");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listSecrets", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	std::vector<Secret> secrets;
@@ -4011,7 +4188,10 @@ std::vector<Secret> PersistentStore::listSecrets(std::string group, std::string 
 }
 
 Secret PersistentStore::findSecretByName(std::string group, std::string cluster, std::string name){
-	auto span = tracer->StartSpan("PersistentStore::findSecretByName");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::findSecretByName", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	auto secrets=listSecrets(group, cluster);
@@ -4027,7 +4207,10 @@ Secret PersistentStore::findSecretByName(std::string group, std::string cluster,
 }
 
 bool PersistentStore::addMonitoringCredential(const S3Credential& cred){
-	auto span = tracer->StartSpan("PersistentStore::addMonitoringCredential");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::addMonitoringCredential", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	if(!cred) {
@@ -4072,7 +4255,10 @@ bool PersistentStore::addMonitoringCredential(const S3Credential& cred){
 }
 
 S3Credential PersistentStore::getMonitoringCredential(const std::string& accessKey){
-	auto span = tracer->StartSpan("PersistentStore::getMonitoringCredential");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::getMonitoringCredential", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//we do not keep these cached, always query
@@ -4111,7 +4297,10 @@ S3Credential PersistentStore::getMonitoringCredential(const std::string& accessK
 }
 
 std::vector<S3Credential> PersistentStore::listMonitoringCredentials(){
-	auto span = tracer->StartSpan("PersistentStore::listMonitoringCredentials");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listMonitoringCredentials", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	std::vector<S3Credential> creds;
@@ -4156,7 +4345,10 @@ std::vector<S3Credential> PersistentStore::listMonitoringCredentials(){
 }
 
 std::tuple<S3Credential,std::string> PersistentStore::allocateMonitoringCredential(){
-	auto span = tracer->StartSpan("PersistentStore::allocateMonitoringCredential");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::allocateMonitoringCredential", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	S3Credential cred;
@@ -4231,7 +4423,10 @@ std::tuple<S3Credential,std::string> PersistentStore::allocateMonitoringCredenti
 }
 
 bool PersistentStore::revokeMonitoringCredential(const std::string& accessKey){
-	auto span = tracer->StartSpan("PersistentStore::revokeMonitoringCredential");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::revokeMonitoringCredential", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	using AV=Aws::DynamoDB::Model::AttributeValue;
@@ -4263,7 +4458,10 @@ bool PersistentStore::revokeMonitoringCredential(const std::string& accessKey){
 }
 
 bool PersistentStore::deleteMonitoringCredential(const std::string& accessKey){
-	auto span = tracer->StartSpan("PersistentStore::deleteMonitoringCredential");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::deleteMonitoringCredential", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	using AV=Aws::DynamoDB::Model::AttributeValue;
@@ -4289,7 +4487,10 @@ bool PersistentStore::deleteMonitoringCredential(const std::string& accessKey){
 }
 
 bool PersistentStore::addPersistentVolumeClaim(const PersistentVolumeClaim& pvc){
-	auto span = tracer->StartSpan("PersistentStore::addPersistentVolumeClaim");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::addPersistentVolumeClaim", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	using Aws::DynamoDB::Model::AttributeValue;
@@ -4337,7 +4538,10 @@ bool PersistentStore::addPersistentVolumeClaim(const PersistentVolumeClaim& pvc)
 }
 
 bool PersistentStore::removePersistentVolumeClaim(const std::string& id){
-	auto span = tracer->StartSpan("PersistentStore::removePersistentVolumeClaim");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::removePersistentVolumeClaim", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//erase cache entries
@@ -4379,7 +4583,10 @@ bool PersistentStore::removePersistentVolumeClaim(const std::string& id){
 }
 
 PersistentVolumeClaim PersistentStore::getPersistentVolumeClaim(const std::string& id){
-	auto span = tracer->StartSpan("PersistentStore::getPersistentVolumeClaim");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::getPersistentVolumeClaim", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//first see if we have this cached
@@ -4444,7 +4651,10 @@ PersistentVolumeClaim PersistentStore::getPersistentVolumeClaim(const std::strin
 }
 
 PersistentVolumeClaim PersistentStore::findPersistentVolumeClaimByName(std::string group, std::string cluster, std::string name){
-	auto span = tracer->StartSpan("PersistentStore::findPersistentVolumeClaimByName");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::findPersistentVolumeClaimByName", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	auto volumes=listPersistentVolumeClaimsByClusterOrGroup(group, cluster);
@@ -4460,7 +4670,10 @@ PersistentVolumeClaim PersistentStore::findPersistentVolumeClaimByName(std::stri
 }
 
 std::vector<PersistentVolumeClaim> PersistentStore::listPersistentVolumeClaims(){
-	auto span = tracer->StartSpan("PersistentStore::listPersistentVolumeClaims");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listPersistentVolumeClaims", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	log_info("Entered listPersistentVolumeClaims()");
@@ -4552,7 +4765,10 @@ std::vector<PersistentVolumeClaim> PersistentStore::listPersistentVolumeClaims()
 }
 
 std::vector<PersistentVolumeClaim> PersistentStore::listPersistentVolumeClaimsByClusterOrGroup(std::string group, std::string cluster){
-	auto span = tracer->StartSpan("PersistentStore::listPersistentVolumeClaimsByClusterOrGroup");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listPersistentVolumeClaimsByClusterOrGroup", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	log_info("Entered List PVC By Group or Cluster");
@@ -4684,7 +4900,10 @@ std::vector<PersistentVolumeClaim> PersistentStore::listPersistentVolumeClaimsBy
 }
 
 Application PersistentStore::findApplication(const std::string& repository, const std::string& appName, const std::string& chartVersion){
-	auto span = tracer->StartSpan("PersistentStore::findApplication");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::findApplication", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	{ //check for cached data first
@@ -4745,7 +4964,10 @@ Application PersistentStore::findApplication(const std::string& repository, cons
 }
 
 std::vector<Application> PersistentStore::fetchApplications(const std::string& repository){
-	auto span = tracer->StartSpan("PersistentStore::fetchApplications");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::fetchApplications", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//Tell helm the terminal is rather wide to prevent truncation of results 
@@ -4787,7 +5009,10 @@ std::vector<Application> PersistentStore::fetchApplications(const std::string& r
 }
 
 std::vector<Application> PersistentStore::listApplications(const std::string& repository){
-	auto span = tracer->StartSpan("PersistentStore::listApplications");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("PersistentStore::listApplications", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 
 	//check for cached data first

--- a/src/SecretCommands.cpp
+++ b/src/SecretCommands.cpp
@@ -74,7 +74,10 @@ struct SecretStringBuffer{
 
 crow::response listSecrets(PersistentStore& store, const crow::request& req){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -154,7 +157,10 @@ crow::response listSecrets(PersistentStore& store, const crow::request& req){
 
 crow::response createSecret(PersistentStore& store, const crow::request& req){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -549,7 +555,10 @@ crow::response createSecret(PersistentStore& store, const crow::request& req){
 crow::response deleteSecret(PersistentStore& store, const crow::request& req,
                             const std::string& secretID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -633,7 +642,10 @@ std::string deleteSecret(PersistentStore& store, const Secret& secret, bool forc
 crow::response getSecret(PersistentStore& store, const crow::request& req,
                          const std::string& secretID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate

--- a/src/Telemetry.cpp
+++ b/src/Telemetry.cpp
@@ -4,19 +4,69 @@
 
 #include <crow.h>
 
+#include "Telemetry.h"
+
 #include "opentelemetry/exporters/otlp/otlp_http_exporter_factory.h"
 #include "opentelemetry/sdk/trace/simple_processor_factory.h"
 #include "opentelemetry/sdk/trace/batch_span_processor_factory.h"
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #include "opentelemetry/trace/provider.h"
 
+//Samplers
+#include "opentelemetry/sdk/trace/samplers/parent.h"
+#include "opentelemetry/sdk/trace/samplers/trace_id_ratio.h"
+
+#include "opentelemetry/trace/semantic_conventions.h"
+
+// Needed for propagating span info through http headers
+#include "opentelemetry/trace/context.h"
+#include "opentelemetry/context/propagation/global_propagator.h"
 #include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/trace/propagation/http_trace_context.h"
 
 namespace trace     = opentelemetry::trace;
 namespace nostd     = opentelemetry::nostd;
 namespace sdktrace = opentelemetry::sdk::trace;
 namespace otlp      = opentelemetry::exporter::otlp;
 namespace resource = opentelemetry::sdk::resource;
+
+// template class from opentel c++ example
+template <typename T>
+class HttpTextMapCarrier : public opentelemetry::context::propagation::TextMapCarrier
+{
+public:
+	HttpTextMapCarrier<T>(T &headers) : headers_(headers) {}
+	HttpTextMapCarrier() = default;
+	virtual opentelemetry::nostd::string_view Get(
+			opentelemetry::nostd::string_view key) const noexcept override
+	{
+		std::string key_to_compare = key.data();
+		// Header's first letter seems to be  automatically capitaliazed by our test http-server, so
+		// compare accordingly.
+		if (key == opentelemetry::trace::propagation::kTraceParent)
+		{
+			key_to_compare = "Traceparent";
+		}
+		else if (key == opentelemetry::trace::propagation::kTraceState)
+		{
+			key_to_compare = "Tracestate";
+		}
+		auto it = headers_.find(key_to_compare);
+		if (it != headers_.end())
+		{
+			return it->second;
+		}
+		return "";
+	}
+
+	virtual void Set(opentelemetry::nostd::string_view key,
+	                 opentelemetry::nostd::string_view value) noexcept override
+	{
+		headers_.insert(std::pair<std::string, std::string>(std::string(key), std::string(value)));
+	}
+
+	T headers_;
+};
 
 ///Initialize opentelemetry tracing for application
 ///\param endpoint url to opentelemetry server endpoint
@@ -34,13 +84,19 @@ void initializeTracer(const std::string& endpoint, const resource::ResourceAttri
 	auto batchProcessor = sdktrace::BatchSpanProcessorFactory::Create(std::move(OLTPExporter), options);
 
 	//configure sampler
-	auto alwaysOnSampler = std::unique_ptr<sdktrace::AlwaysOnSampler>
-			(new sdktrace::AlwaysOnSampler);
+	//		auto alwaysOnSampler = std::unique_ptr<sdktrace::AlwaysOnSampler>
+	//				(new sdktrace::AlwaysOnSampler);
+	// configure sampler to sample based on the parent span and fall back on
+	// sampling 50% if there's no parent span
+	auto ratioSampler = std::shared_ptr<sdktrace::TraceIdRatioBasedSampler>
+			(new sdktrace::TraceIdRatioBasedSampler(samplingRatio));
+	auto parentSampler = std::unique_ptr<sdktrace::ParentBasedSampler>
+			(new sdktrace::ParentBasedSampler(ratioSampler));
 
 	// configure trace provider
 	auto resource = resource::Resource::Create(resources);
 	std::shared_ptr<trace::TracerProvider> provider =
-			sdktrace::TracerProviderFactory::Create(std::move(processor), resource, std::move(alwaysOnSampler));
+			sdktrace::TracerProviderFactory::Create(std::move(processor), resource, std::move(parentSampler));
 
 	// Set the global trace provider
 	trace::Provider::SetTracerProvider(provider);
@@ -56,6 +112,52 @@ nostd::shared_ptr<trace::Tracer> getTracer(const std::string& tracerName)
 	return provider->GetTracer(tracerName);
 }
 
+void setWebSpanAttributes(std::map<std::string, std::string>& spanAttributes, const crow::request& req) {
+	spanAttributes = {
+			{trace::SemanticConventions::HTTP_METHOD,    crow::method_name(req.method)},
+			{trace::SemanticConventions::HTTP_SCHEME,    "http"},
+			{trace::SemanticConventions::HTTP_CLIENT_IP, req.remote_endpoint}};
+	auto val = req.headers.find("Host");
+	if (val != req.headers.end()) {
+		std::string host = val->second;
+		auto commaPos = host.find(':');
+		if (commaPos != std::string::npos) {
+			spanAttributes[trace::SemanticConventions::NET_HOST_NAME] = host.substr(0, commaPos);
+			spanAttributes[trace::SemanticConventions::NET_HOST_PORT] = host.substr(commaPos);
+		} else {
+			spanAttributes[trace::SemanticConventions::NET_HOST_NAME] = host;
+		}
+	}
+	val = req.headers.find("Content-Length");
+	if (val != req.headers.end()) {
+		spanAttributes[trace::SemanticConventions::HTTP_REQUEST_CONTENT_LENGTH] = val->second;
+	}
+}
+
+trace::StartSpanOptions getWebSpanOptions(const crow::request& req) {
+	trace::StartSpanOptions spanOptions;
+	spanOptions.kind = trace::SpanKind::kServer;
+	auto propagator = opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+	auto current_ctx = opentelemetry::context::RuntimeContext::GetCurrent();
+	const HttpTextMapCarrier <std::map<std::string, std::string>> carrier =
+			(std::map<std::string, std::string> &)req.headers;
+	auto new_context = propagator->Extract(carrier, current_ctx);
+	spanOptions.parent = opentelemetry::trace::GetSpan(new_context)->GetContext();
+	return spanOptions;
+}
+
+void setInternalSpanAttributes(std::map<std::string, std::string>& spanAttributes) {
+	// No-op for now
+	static_assert(true, "NO OP");
+}
+
+trace::StartSpanOptions getInternalSpanOptions() {
+	trace::StartSpanOptions spanOptions;
+	spanOptions.kind = trace::SpanKind::kServer;
+	return spanOptions;
+}
+
+
 ///Set attributes for a span based on a crow request
 ///\param span span to populate with attributes
 ///\param req crow request
@@ -65,7 +167,6 @@ void populateSpan(nostd::shared_ptr<trace::Span>& span, const crow::request& req
 	span->SetAttribute("http.flavor", "1.1");
 	span->SetAttribute("http.scheme", "http");
 	span->SetAttribute("http.target", req.url);
-	span->SetAttribute("http.scheme", req.remote_endpoint);
 	span->SetAttribute("http.client_ip", req.remote_endpoint);
 	span->SetAttribute("net.app.protocol.name", "http");
 	// get host/port

--- a/src/UserCommands.cpp
+++ b/src/UserCommands.cpp
@@ -6,7 +6,10 @@
 
 crow::response listUsers(PersistentStore& store, const crow::request& req) {
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	span->AddEvent("Authenticating user");
@@ -57,7 +60,10 @@ crow::response listUsers(PersistentStore& store, const crow::request& req) {
 
 crow::response createUser(PersistentStore& store, const crow::request& req){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	span->AddEvent("Authenticating user");
@@ -233,7 +239,10 @@ crow::response createUser(PersistentStore& store, const crow::request& req){
 
 crow::response getUserInfo(PersistentStore& store, const crow::request& req, const std::string uID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	span->AddEvent("Authenticating user");
@@ -293,7 +302,10 @@ crow::response getUserInfo(PersistentStore& store, const crow::request& req, con
 
 crow::response whoAreThey(PersistentStore& store, const crow::request& req) {
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	span->AddEvent("Authenticating user");
@@ -339,7 +351,10 @@ crow::response whoAreThey(PersistentStore& store, const crow::request& req) {
 
 crow::response updateUser(PersistentStore& store, const crow::request& req, const std::string uID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	span->AddEvent("Authenticating user");
@@ -470,7 +485,10 @@ crow::response updateUser(PersistentStore& store, const crow::request& req, cons
 
 crow::response deleteUser(PersistentStore& store, const crow::request& req, const std::string uID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	span->AddEvent("Authenticating user");
@@ -534,7 +552,10 @@ crow::response deleteUser(PersistentStore& store, const crow::request& req, cons
 
 crow::response listUsergroups(PersistentStore& store, const crow::request& req, const std::string uID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	span->AddEvent("Authenticating user");
@@ -588,7 +609,10 @@ crow::response listUsergroups(PersistentStore& store, const crow::request& req, 
 crow::response addUserToGroup(PersistentStore& store, const crow::request& req, 
 						   const std::string uID, const std::string& groupID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	span->AddEvent("Authenticating user");
@@ -644,7 +668,10 @@ crow::response addUserToGroup(PersistentStore& store, const crow::request& req,
 crow::response removeUserFromGroup(PersistentStore& store, const crow::request& req, 
 								const std::string uID, const std::string& groupID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	span->AddEvent("Authenticating user");
@@ -692,7 +719,10 @@ crow::response removeUserFromGroup(PersistentStore& store, const crow::request& 
 
 crow::response findUser(PersistentStore& store, const crow::request& req){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	span->AddEvent("Authenticating user");
@@ -741,7 +771,10 @@ crow::response findUser(PersistentStore& store, const crow::request& req){
 
 crow::response replaceUserToken(PersistentStore& store, const crow::request& req, const std::string uID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	span->AddEvent("Authenticating user");

--- a/src/VersionCommands.cpp
+++ b/src/VersionCommands.cpp
@@ -9,7 +9,10 @@
 
 crow::response serverVersionInfo(){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan("/version");
+	std::map<std::string, std::string> attributes;
+	setInternalSpanAttributes(attributes);
+	auto options = getInternalSpanOptions();
+	auto span = tracer->StartSpan("/version", attributes, options);
 	auto scope = tracer->WithActiveSpan(span);
 	rapidjson::Document result(rapidjson::kObjectType);
 	rapidjson::Document::AllocatorType& alloc = result.GetAllocator();

--- a/src/VolumeClaimCommands.cpp
+++ b/src/VolumeClaimCommands.cpp
@@ -18,7 +18,10 @@ crow::response listVolumeClaims(PersistentStore& store, const crow::request& req
 	high_resolution_clock::time_point t1 = high_resolution_clock::now();
 	// Take the user token presented in the request and authenticate the user against the PersistentStore
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -149,7 +152,10 @@ crow::response listVolumeClaims(PersistentStore& store, const crow::request& req
 
 crow::response fetchVolumeClaimInfo(PersistentStore& store, const crow::request& req, const std::string& claimID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -271,7 +277,10 @@ crow::response fetchVolumeClaimInfo(PersistentStore& store, const crow::request&
 
 crow::response createVolumeClaim(PersistentStore& store, const crow::request& req){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate
@@ -719,7 +728,10 @@ crow::response createVolumeClaim(PersistentStore& store, const crow::request& re
 
 crow::response deleteVolumeClaim(PersistentStore& store, const crow::request& req, const std::string& claimID){
 	auto tracer = getTracer();
-	auto span = tracer->StartSpan(req.url);
+	std::map<std::string, std::string> attributes;
+	setWebSpanAttributes(attributes, req);
+	auto options = getWebSpanOptions(req);
+	auto span = tracer->StartSpan(req.url, attributes, options);
 	populateSpan(span, req);
 	auto scope = tracer->WithActiveSpan(span);
 	//authenticate

--- a/src/slate_service.cpp
+++ b/src/slate_service.cpp
@@ -411,8 +411,12 @@ crow::response multiplex(crow::SimpleApp& server, PersistentStore& store, const 
 }
 
 int main(int argc, char* argv[]){
-	// disable sigpipe
+	// Needed to work on gke since the load balancer occasionally
+	// closes TCP connections in a way that results in the rocky 9
+	// kernel sending a SIGPIPE to the api server and crashes it
+	// if this signal isn't ignored
 	signal(SIGPIPE, SIG_IGN);
+
 	Configuration config(argc, argv);
 
 	// setup opentelemetry


### PR DESCRIPTION
* Allows opentelemetry to be disabled or sampling to be disabled
* Use head sampling with a 50% ratio by default
* Properly setup spans on creation (should populate span settings better)
* Propagate contexts from http request headers so that we can link traces with traces from the portal or the client
