### PR TITLE
Update slate api server container to limit cpu usage

### DIFF
--- a/resources/chart/templates/deployment.yml
+++ b/resources/chart/templates/deployment.yml
@@ -29,6 +29,9 @@ spec:
     spec:
       containers:
         - name: slate-api
+          resources:
+            limits:
+              cpu: "250m"
           image: "{{ .Values.harbor.hostname }}/{{ .Values.harbor.projectID }}/slate-api:{{ .Chart.AppVersion }}"
           imagePullPolicy: Always
           ports:


### PR DESCRIPTION
Limit cpu usage, this should hopefully help with the segfault issues on gke