### PR TITLE
Deprecating the develop branch

### DIFF
--- a/.github/workflows/aws-cpp-sdk.yml
+++ b/.github/workflows/aws-cpp-sdk.yml
@@ -203,7 +203,7 @@ jobs:
           ref: gh-pages
 
       - name: Configure Git
-        uses: slateci/github-actions/.github/actions/configure-git@v15
+        uses: slateci/github-actions/.github/actions/configure-git@v16
 
       - name: Commit artifacts
         working-directory: ./checkout

--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -32,7 +32,7 @@ jobs:
     name: SLATE Remote Client Pre-release
     needs:
       - workflow-props
-    uses: slateci/github-actions/.github/workflows/slate-client-prerelease.yml@v15
+    uses: slateci/github-actions/.github/workflows/slate-client-prerelease.yml@v16
 
   notifications:
     name: Notifications
@@ -44,6 +44,6 @@ jobs:
 
     steps:
       - name: Notify Slack of Failure
-        uses: slateci/github-actions/.github/actions/slack-notify-failure@v15
+        uses: slateci/github-actions/.github/actions/slack-notify-failure@v16
         with:
           slack_bot_token: '${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -31,7 +31,7 @@ jobs:
   workflow-props:
     name: Workflow Properties
     if: ${{ github.event.inputs.confirm == 'CONFIRM' }}
-    uses: slateci/github-actions/.github/workflows/workflow-props.yml@v15
+    uses: slateci/github-actions/.github/workflows/workflow-props.yml@v16
     with:
       helm_release_namespace: production
       prod_git_ref: v${{ github.event.inputs.release-semver }}
@@ -41,7 +41,7 @@ jobs:
     if: ${{ github.event.inputs.confirm == 'CONFIRM' }}
     needs:
       - workflow-props
-    uses: slateci/github-actions/.github/workflows/chart-release-checks.yml@v15
+    uses: slateci/github-actions/.github/workflows/chart-release-checks.yml@v16
     with:
       helm_release_namespace: production
       helm_release_prefix: slate-api
@@ -57,7 +57,7 @@ jobs:
     if: ${{ github.event.inputs.confirm == 'CONFIRM' }}
     needs:
       - checks
-    uses: slateci/github-actions/.github/workflows/helm-upgrade.yml@v15
+    uses: slateci/github-actions/.github/workflows/helm-upgrade.yml@v16
     with:
       helm_release_namespace: production
       helm_release_prefix: slate-api
@@ -72,7 +72,7 @@ jobs:
     if: ${{ github.event.inputs.confirm == 'CONFIRM' }}
     needs:
       - checks
-    uses: slateci/github-actions/.github/workflows/slate-client-release.yml@v15
+    uses: slateci/github-actions/.github/workflows/slate-client-release.yml@v16
 
   notifications:
     name: Notifications
@@ -86,6 +86,6 @@ jobs:
 
     steps:
       - name: Notify Slack of Failure
-        uses: slateci/github-actions/.github/actions/slack-notify-failure@v15
+        uses: slateci/github-actions/.github/actions/slack-notify-failure@v16
         with:
           slack_bot_token: '${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}'

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,20 +1,12 @@
-name: "Deploy: DEV or STAGING"
+name: "Deploy: STAGING"
 concurrency:
-  group: deploy-${{ github.repository }}
+  group: deploy-staging-${{ github.repository }}
 
 on:
   workflow_dispatch:
     inputs:
-      helm-release-namespace:
-        description: 'Choose an environment:'
-        type: choice
-        default: development
-        options:
-          - development
-          - staging
-        required: true
       confirm:
-        description: 'Type "CONFIRM" to deploy to Google.'
+        description: 'Type "CONFIRM" to deploy to STAGING.'
         required: true
         type: string
 
@@ -35,9 +27,9 @@ jobs:
   bump-appversion:
     name: Bump appVersion
     if: ${{ github.event.inputs.confirm == 'CONFIRM' }}
-    uses: slateci/github-actions/.github/workflows/chart-bump-appversion.yml@v15
+    uses: slateci/github-actions/.github/workflows/chart-bump-appversion.yml@v16
     with:
-      helm_release_namespace: ${{ github.event.inputs.helm-release-namespace }}
+      helm_release_namespace: staging
       helm_release_prefix: slate-api
     secrets:
       gc_compute_zone: ${{ secrets.GCLOUD_COMPUTE_ZONE }}
@@ -50,18 +42,18 @@ jobs:
     if: ${{ github.event.inputs.confirm == 'CONFIRM' }}
     needs:
       - bump-appversion
-    uses: slateci/github-actions/.github/workflows/workflow-props.yml@v15
+    uses: slateci/github-actions/.github/workflows/workflow-props.yml@v16
     with:
-      helm_release_namespace: ${{ github.event.inputs.helm-release-namespace }}
+      helm_release_namespace: staging
 
   checks:
     name: Checks
     if: ${{ github.event.inputs.confirm == 'CONFIRM' }}
     needs:
       - workflow-props
-    uses: slateci/github-actions/.github/workflows/chart-release-checks.yml@v15
+    uses: slateci/github-actions/.github/workflows/chart-release-checks.yml@v16
     with:
-      helm_release_namespace: ${{ github.event.inputs.helm-release-namespace }}
+      helm_release_namespace: staging
       helm_release_prefix: slate-api
     secrets:
       gc_compute_zone: ${{ secrets.GCLOUD_COMPUTE_ZONE }}
@@ -74,11 +66,11 @@ jobs:
     if: ${{ github.event.inputs.confirm == 'CONFIRM' }}
     needs:
       - checks
-    uses: slateci/github-actions/.github/workflows/image-build-push.yml@v15
+    uses: slateci/github-actions/.github/workflows/image-build-push.yml@v16
     with:
       cr_domain: hub.opensciencegrid.org
       cr_repository: slate-api
-      helm_release_namespace: ${{ github.event.inputs.helm-release-namespace }}
+      helm_release_namespace: staging
     secrets:
       cr_password: ${{ secrets.CR_PASSWORD }}
       cr_username: ${{ secrets.CR_USERNAME }}
@@ -88,9 +80,9 @@ jobs:
     if: ${{ github.event.inputs.confirm == 'CONFIRM' }}
     needs:
       - image
-    uses: slateci/github-actions/.github/workflows/helm-upgrade.yml@v15
+    uses: slateci/github-actions/.github/workflows/helm-upgrade.yml@v16
     with:
-      helm_release_namespace: ${{ github.event.inputs.helm-release-namespace }}
+      helm_release_namespace: staging
       helm_release_prefix: slate-api
     secrets:
       gc_compute_zone: ${{ secrets.GCLOUD_COMPUTE_ZONE }}
@@ -103,7 +95,7 @@ jobs:
     if: ${{ github.event.inputs.confirm == 'CONFIRM' }}
     needs:
       - checks
-    uses: slateci/github-actions/.github/workflows/slate-client-prerelease.yml@v15
+    uses: slateci/github-actions/.github/workflows/slate-client-prerelease.yml@v16
 
   notifications:
     name: Notifications
@@ -120,6 +112,6 @@ jobs:
 
     steps:
       - name: Notify Slack of Failure
-        uses: slateci/github-actions/.github/actions/slack-notify-failure@v15
+        uses: slateci/github-actions/.github/actions/slack-notify-failure@v16
         with:
           slack_bot_token: '${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}'

--- a/.github/workflows/otel-cpp-client.yml
+++ b/.github/workflows/otel-cpp-client.yml
@@ -213,7 +213,7 @@ jobs:
           ref: gh-pages
 
       - name: Configure Git
-        uses: slateci/github-actions/.github/actions/configure-git@v15
+        uses: slateci/github-actions/.github/actions/configure-git@v16
 
       - name: Commit artifacts
         working-directory: ./checkout

--- a/.github/workflows/pr-chart.yml
+++ b/.github/workflows/pr-chart.yml
@@ -5,7 +5,6 @@ concurrency:
 on:
   pull_request:
     branches:
-      - develop
       - master
     paths:
       - "resources/chart/**"
@@ -13,7 +12,7 @@ on:
 jobs:
   chart:
     name: Check Helm Chart
-    uses: slateci/github-actions/.github/workflows/chart-diff-lint.yml@v15
+    uses: slateci/github-actions/.github/workflows/chart-diff-lint.yml@v16
     with:
       helm_release_prefix: slate-api
     secrets:

--- a/.github/workflows/pr-client.yml
+++ b/.github/workflows/pr-client.yml
@@ -5,7 +5,6 @@ concurrency:
 on:
   pull_request:
     branches:
-      - develop
       - master
     paths-ignore:
       - ".github/**"
@@ -15,4 +14,4 @@ on:
 jobs:
   build-client:
     name: Build Remote Client
-    uses: slateci/github-actions/.github/workflows/slate-client-build.yml@v15
+    uses: slateci/github-actions/.github/workflows/slate-client-build.yml@v16

--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -5,7 +5,6 @@ concurrency:
 on:
   pull_request:
     branches:
-      - develop
       - master
     paths-ignore:
       - ".github/**"
@@ -15,6 +14,6 @@ on:
 jobs:
   lint-scan:
     name: Lint/scan image
-    uses: slateci/github-actions/.github/workflows/image-lint-scan.yml@v15
+    uses: slateci/github-actions/.github/workflows/image-lint-scan.yml@v16
     with:
       file: ./resources/docker/Dockerfile

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ on:
       branch:
         description: 'Branch under test:'
         required: false
-        default: develop
+        default: master
         type: string
       kubernetes-version:
         description: 'Version of Kubernetes to use (e.g. 1.24.9):'
@@ -178,6 +178,6 @@ jobs:
 
     steps:
       - name: Notify Slack of Failure
-        uses: slateci/github-actions/.github/actions/slack-notify-failure@v15
+        uses: slateci/github-actions/.github/actions/slack-notify-failure@v16
         with:
           slack_bot_token: '${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}'

--- a/resources/chart/Chart.yaml
+++ b/resources/chart/Chart.yaml
@@ -26,4 +26,4 @@ version: "1.0.4"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: '1.0.43'
+appVersion: "1.0.44-pre.20230422-173744"


### PR DESCRIPTION
The *master* branch now powers STAGING while tags power PRODUCTION. The *develop* branch is no longer necessary.